### PR TITLE
Sync parent-theme docs with current codebase state

### DIFF
--- a/wp-content/themes/fivetwofive-theme/CLAUDE.md
+++ b/wp-content/themes/fivetwofive-theme/CLAUDE.md
@@ -4,9 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-FiveTwoFive Theme is a custom WordPress parent theme (v0.9.2) for FiveTwoFive Creative projects. It uses ACF Pro for modular page building, WordPress Customizer for global styling, and a Gulp-based asset pipeline.
+FiveTwoFive Theme is a custom WordPress parent theme (v1.0.1) for FiveTwoFive Creative projects. It uses ACF Pro for modular page building, WordPress Customizer for global styling, and a Gulp-based asset pipeline.
 
-**Requires:** ACF Pro, Bootstrap 5.2.3, jQuery (WordPress bundled)
+**Requires:** ACF Pro, Bootstrap 5.2.3
 
 ## Development Commands
 
@@ -63,7 +63,6 @@ Core scripts in `assets/src/js/`:
 - `template-modules.js` — ScrollReveal integration for module animations
 
 Module scripts in `assets/src/js/modules/`:
-- `module-accordion.js` — jQuery UI accordion
 - `module-announcement.js` — dismissible banners
 - `module-resource.js` — AJAX filtering + pagination via REST API
 - `module-works.js` — portfolio filtering + ScrollReveal
@@ -80,7 +79,7 @@ Assets are loaded conditionally:
 2. **Post-type specific** — `single-event.css`, `single-resource.css`, `single-music.css`
 3. **Blog/archive** — `view-toggle.js`
 4. **Single posts** — `single-post.js` + Popper.js
-5. **Module template only** — Fancybox, Swiper, ScrollReveal, all module scripts
+5. **Module template only** — GLightbox, Swiper, ScrollReveal, all module scripts
 
 Scripts in the `$defer_scripts` array are automatically given `defer` attribute via `fivetwofive_theme_defer_scripts()`.
 
@@ -137,7 +136,7 @@ add_filter( 'fivetwofive_theme_svg_icons_ui', function( $arr ) {
 | module-content-and-media | Content + image/video |
 | module-cta | Call-to-action |
 | module-events | Event listing with filters |
-| module-gallery | Fancybox lightbox gallery |
+| module-gallery | GLightbox lightbox gallery |
 | module-hero | Hero with background options |
 | module-multi-column | 2–5 column responsive grid |
 | module-resources | AJAX-filtered resource list |

--- a/wp-content/themes/fivetwofive-theme/CLAUDE.md
+++ b/wp-content/themes/fivetwofive-theme/CLAUDE.md
@@ -57,7 +57,7 @@ assets/src/sass/
 ### JavaScript Architecture
 
 Core scripts in `assets/src/js/`:
-- `navigation.js` — mobile nav
+- `navigation.js` — mobile nav. **Build exception:** hand-maintained directly in `assets/dist/js/navigation.js` — there is no `src` source, and it's enqueued unminified (no build/transpile/lint step). Edit the `dist` file directly. Bringing it into the build is tracked in [#59](https://github.com/jaballer/fivetwofive-cw/issues/59).
 - `view-toggle.js` — grid/list view with `localStorage` persistence
 - `single-post.js` — social sharing tooltips (Popper.js)
 - `template-modules.js` — ScrollReveal integration for module animations

--- a/wp-content/themes/fivetwofive-theme/README.md
+++ b/wp-content/themes/fivetwofive-theme/README.md
@@ -306,13 +306,13 @@ Then initialize the theme's task runner (gulp) by running `gulp` in the command 
 
 ## Contribute
 
-- Issue Tracker: https://github.com/capitalJT/fivetwofive-cw/issues
-- Source Code: https://github.com/capitalJT/fivetwofive-cw
+- Issue Tracker: https://github.com/jaballer/fivetwofive-cw/issues
+- Source Code: https://github.com/jaballer/fivetwofive-cw
 
 # Development Setup
 
 ## Prerequisites
-- Node.js (v14 or higher)
+- Node.js (v18 or higher)
 - Local by Flywheel or similar local WordPress development environment
 - Composer (for PHP dependencies)
 
@@ -352,7 +352,7 @@ To access the database in Local by Flywheel:
 fivetwofive-theme/
 ├── assets/                 # Compiled assets and source files
 │   ├── dist/              # Compiled files
-│   └── src/               # Source files (JS, SASS, images)
+│   └── src/               # Source files (JS, SASS)
 ├── inc/                   # Theme PHP includes
 ├── template-parts/        # Reusable template parts
 ├── modules/               # Module template files


### PR DESCRIPTION
## What

Corrects accumulated documentation drift in the parent theme's `CLAUDE.md` and `README.md` so they match the actual codebase. No code changes — docs only.

## Why

The modernization phases (#47 jQuery removal, #52 Font Awesome + Fancybox→GLightbox) and the recent #55 imagemin cleanup left the docs describing libraries and files that no longer exist. Every change below was verified against the code.

## CLAUDE.md
- **Theme version `0.9.2` → `1.0.1`** — matches `style.css` (and `package.json`)
- **Dropped "jQuery (WordPress bundled)" from Requires** — removed in Phase 2 (#47); `inc/public/assets.php` has zero front-end jQuery dependencies
- **Removed `module-accordion.js`** from the module-scripts list — the source file was deleted in #47 (the module's PHP template remains; its table row stays)
- **Fancybox → GLightbox** in the conditional asset-loading list and the `module-gallery` row (#52)

## README.md
- **Repo URLs** `capitalJT/...` → `jaballer/...` (matches the current remote)
- **Node floor `v14` → `v18`** — v14 is EOL; current devDependencies (e.g. cssnano 7) require ≥18.12
- **Removed nonexistent `assets/src/images`** from the structure tree

## Verification
- `jquery` / `fancybox` / `font-awesome` — **0** references in theme PHP/JS (excl. `dist/` vendor + the accurate `fivetwofive-cta` admin enqueue, which keeps WP-bundled jQuery UI)
- ScrollReveal / Swiper still present and documented (deferred → #50 / #51)
- Doc screenshots under `dist/images/documentation/` confirmed intact (committed assets, never build output)

## Context

Part of #39 (modernization epic — documentation accuracy). The related issue bodies (#39, #43) were already updated separately to reflect the imagemin removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)