### PR TITLE
chore(skills): add Tier-1 git-workflow skills + fix stale theme rule

### DIFF
--- a/.claude/skills/ftf-commit-feature/SKILL.md
+++ b/.claude/skills/ftf-commit-feature/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: ftf-commit-feature
+description: >
+  Best practices for committing completed work on the FiveTwoFive WordPress
+  site. Use this skill when the user says "commit", "let's commit", "commit
+  these changes", "I'm ready to commit", or "commit and push". Covers rebuilding
+  theme assets, staging the right files (the deny-all `.gitignore` silently
+  ignores new files), a WordPress-specific hostile-read checklist, writing a
+  good commit message, and opening a PR. Trigger any time work is complete and
+  ready to be committed — don't wait for the user to ask about best practices
+  explicitly.
+---
+
+# Commit Feature — FiveTwoFive
+
+Before committing, work through these steps in order. There is no CI on this repo — these steps are the only gate, so don't skip them.
+
+## 1. Confirm you're on a working branch
+
+```bash
+git branch --show-current
+```
+
+Any of the prefixes from `/ftf-new-branch` is acceptable: `feature/`, `fix/`, `refactor/`, `docs/`, `chore/`, `review/`. Never commit directly to `master`. If you're on `master`, stop and **invoke `/ftf-new-branch`** first.
+
+## 2. Rebuild theme assets (the load-bearing pre-push step)
+
+The deployed site serves the **compiled** files in each theme's `assets/dist/`. If you edited SCSS or JS source and don't rebuild, the live site ships stale assets. Build **only the theme(s) you touched**:
+
+```bash
+# Parent theme (Gulp build runs SCSS + ESLint + JS; ESLint failure fails the build)
+cd wp-content/themes/fivetwofive-theme && npm run build
+
+# Child theme (SCSS + JS; bundles GSAP)
+cd wp-content/themes/fivetwofive-theme-child && npm run build
+```
+
+- Run from the host, not inside a container (native Gulp toolchain).
+- A clean build is the bar. If ESLint fails the parent build, fix the lint error — don't bypass it.
+- The regenerated `assets/dist/` CSS/JS **must be committed** (step 5). `*.map` files are gitignored — leave them.
+- If you only touched PHP/templates (no SCSS/JS source change), no rebuild is needed — say so explicitly.
+
+### Agent Delegation
+
+If both themes changed, the two builds are independent and can run as parallel sub-agents. Both must finish clean before step 4.
+
+## 3. Note on formatting / linting
+
+- **JS**: ESLint (`@wordpress/eslint-plugin`) runs automatically inside the parent theme's Gulp `build` — there's no separate command.
+- **PHP**: there is no automated formatter or linter configured (no phpcs/phpcbf). Follow the WordPress PHP Coding Standards by hand and match surrounding code. See `.cursor/rules/wordpress-developer-rules.mdc`.
+
+## 4. Pre-push self-review (hostile read with enumeration)
+
+Before staging, read the full diff as if you were a cold reviewer seeing the change for the first time. The goal is to **find what's broken**, not confirm the implementation. There are no tests here — the hostile read *is* the safety net.
+
+```bash
+git status
+git diff
+```
+
+### 4a. The hostile-read rules
+
+Apply each rule and **enumerate** which file/function pairs you applied it to. "I checked everything" means the rule wasn't run.
+
+1. **Cross-file consistency.** Are sibling functions (CPT registrations, query builders, enqueue functions, template parts) consistent? Diff them line-by-line; don't eyeball.
+2. **Destination behavior.** For every template/URL/shortcode changed, did the *rendered output* change as intended for every context (logged-in vs. guest, archive vs. single, mobile vs. desktop)?
+3. **Parent vs. child context.** For every changed function, confirm it lives in the right theme. Portfolio-specific behavior belongs in the **child theme**; framework-level changes belong in the **parent**. A child override shadows the parent — make sure you edited the one that's actually loaded.
+4. **Removed surface.** For every deleted template/function/hook/shortcode, grep for remaining inbound references (`get_template_part`, `do_shortcode`, `add_action`/`add_filter`, `apply_filters`). For every renamed symbol, grep both old and new names.
+5. **Error / empty paths.** Does each `if (! $x)` branch and every loop over a query leave a sane state when the query is empty or a field is missing? Provide fallbacks for missing ACF fields / images.
+6. **New-concept follow-through.** When introducing a new CPT, taxonomy, ACF field, image size, or shortcode, grep for every site that must also reference it (template, enqueue, registration, `acf-json/` sync, rewrite flush). Coverage is binary — partial coverage is silent breakage.
+
+Required output before declaring the read clean — one concrete line per rule with file/function references (a vague or empty line means the rule wasn't applied; **do not push** until every line is concrete):
+
+```
+Rule 1 (cross-file consistency): diffed [fn A in file:line] vs [fn B in file:line]; consistent on [...], differs on [..., why intentional]
+Rule 2 (destination behavior): changed [template/shortcode in file:line]; output for [context] is [unchanged / changed thus]
+Rule 3 (parent vs child): edited [fn in theme/file:line]; correct theme because [...]; no shadowing override at [...]
+Rule 4 (removed surface): grepped [old + new name] in [scope]; remaining refs [none / list]
+Rule 5 (error/empty paths): [query/field in file:line] handles empty via [fallback]
+Rule 6 (new-concept follow-through): introduced [CPT/field/size/shortcode]; sites that must reference it [list of file:line]; coverage [all hit / misses]
+```
+
+### 4b. WordPress bug-class checklist
+
+Run each check against the current diff and record the result. These are the classes that actually bite a WordPress theme/plugin.
+
+| # | Check | Greppable signal | Required action |
+|---|---|---|---|
+| 1 | Unescaped output | `echo`/`<?=` of a variable, `get_field()`, `get_post_meta()`, or `$_*` in markup without `esc_*` | Wrap on output: `esc_html()` / `esc_attr()` / `esc_url()` text; `wp_kses_post()` for rich HTML. Escape late, at the point of output. |
+| 2 | Unsanitized input | Reads `$_POST` / `$_GET` / `$_REQUEST` / `$_SERVER` | Sanitize on input: `sanitize_text_field()`, `absint()`, `sanitize_email()`, etc. |
+| 3 | Missing nonce on form/AJAX | New `<form>`, `admin-ajax` handler, or REST mutation | Issue `wp_nonce_field()` / `wp_create_nonce()` and verify with `check_admin_referer()` / `wp_verify_nonce()` before acting. |
+| 4 | Missing `ABSPATH` guard | New `.php` file in theme/plugin | Add `if ( ! defined( 'ABSPATH' ) ) { exit; }` at the top. |
+| 5 | Unprepared DB query | `$wpdb->query(` / `->get_results(` with interpolated vars | Use `$wpdb->prepare()`; prefer `WP_Query` / `get_posts()` over raw SQL. |
+| 6 | Edited parent when child was right | Diff touches `fivetwofive-theme/` for portfolio-specific behavior | Move it to the child theme override unless it's an intentional framework change (confirm in PR "Decisions baked in"). |
+| 7 | ACF field group ↔ JSON drift | Diff touches `acf-json/*.json` OR you changed a field group in wp-admin | The two must move together. Review the generated `acf-json/` diff and commit it; never commit a code change that assumes fields the JSON doesn't define. |
+| 8 | CPT/taxonomy/rewrite change without flush | Diff changes `register_post_type` / `register_taxonomy` args, slugs, or rewrite rules | Permalinks 404 until rewrite rules flush. Flush once (visit Settings → Permalinks, or `flush_rewrite_rules()` on activation only) and note it in the PR. |
+| 9 | Stale compiled assets | Diff changes `assets/src` SCSS/JS but no matching `assets/dist` change | Rebuild (step 2) and stage the `dist` output; the live site serves `dist`. |
+| 10 | New file silently gitignored | New plugin/theme dir, or file outside the `.gitignore` whitelist | Add the `!wp-content/...` exception to `.gitignore` first; confirm with `git check-ignore <path>` (no output = tracked). |
+| 11 | Function/hook prefix collision | New global `function`/hook without a project prefix | Prefix with `fivetwofive_` (parent) or `fivetwofive_child_` (child); CPT/tax slugs use `ftf_`. |
+| 12 | Hardcoded asset tag | New `<script>` / `<link>` in markup | Use `wp_enqueue_script()` / `wp_enqueue_style()` with deps + a version, loaded conditionally where needed. |
+| 13 | Untranslated UI string | New user-facing string in PHP | Wrap in `__()` / `esc_html__()` / `_e()` with the correct text domain. |
+| 14 | New CPT not REST-exposed | New `register_post_type` without `show_in_rest` | Add `'show_in_rest' => true` for Gutenberg/REST compatibility (per the project CPT rules). |
+
+For each check, write a one-line answer (`N/A — <why>`, or `<action> at file:line`):
+
+```
+[1] escaping: N/A — no dynamic output added, OR esc_html() at file:line
+[2] sanitization: N/A — no superglobals read, OR sanitize_text_field() at file:line
+[3] nonce: N/A — no form/AJAX, OR wp_verify_nonce() at file:line
+[4] ABSPATH guard: N/A — no new PHP file, OR added at file:line
+[5] $wpdb->prepare: N/A — no raw SQL, OR prepared at file:line
+[6] parent-vs-child: N/A — framework change, OR moved to child at file:line
+[7] ACF JSON sync: N/A — no field change, OR acf-json/ diff reviewed + staged
+[8] rewrite flush: N/A — no CPT/slug change, OR flushed + noted in PR
+[9] compiled assets: N/A — no src change, OR rebuilt + staged dist at path
+[10] gitignore whitelist: N/A — no new tracked path, OR added exception + git check-ignore clean
+[11] prefix collision: N/A — no new global, OR prefixed at file:line
+[12] enqueue: N/A — no asset tag, OR wp_enqueue_* at file:line
+[13] i18n: N/A — no UI string, OR __() with text domain at file:line
+[14] show_in_rest: N/A — no new CPT, OR added at file:line
+```
+
+### 4c. Cross-cutting concerns
+
+- **Internal contradictions** — did a change in one place leave a stale assertion in another?
+- **Stale references** — examples, "see step N" pointers, code snippets, readme/changelog lines that reference the old structure.
+- **Sweep coverage** — if you fixed pattern X in one file, grep for X elsewhere; sibling files (CPT plugins, module templates) routinely hide the same bug.
+
+If the self-review surfaces something, fix it now — same diff, no extra commit.
+
+## 5. Stage only the right files
+
+This repo's `.gitignore` is **deny-all-then-whitelist** (`/*` then `!wp-content/...`). That flips the usual staging risk:
+
+- **The usual over-staging risk is mostly handled** — `node_modules`, `*.map`, `.env`, `*.sql`, uploads, and third-party plugins are already ignored.
+- **The real risk is under-staging**: a brand-new plugin/theme dir is **silently ignored** until you add its `!wp-content/...` exception. Verify before committing:
+
+  ```bash
+  git status --short          # new files should appear; if a new dir is missing, it's gitignored
+  git check-ignore -v wp-content/plugins/<new-plugin>   # any output = ignored; fix .gitignore
+  ```
+
+Stage specific paths by name (include rebuilt `dist` output):
+
+```bash
+git add wp-content/themes/fivetwofive-theme-child/template-parts/modules/<file>.php
+git add wp-content/themes/fivetwofive-theme-child/assets/dist/css/style.css
+git add .gitignore   # if you added a whitelist exception
+```
+
+Double-check you are **not** staging `.env` (child theme BrowserSync config) or `*.map` — both should already be ignored, but confirm.
+
+## 6. Write a good commit message
+
+```
+type(scope): short description (under 72 chars)
+
+Optional body explaining the why, not the what. Reference any
+relevant context or decisions made during development.
+
+Closes #123
+```
+
+**Types:** `feat`, `fix`, `refactor`, `docs`, `chore`, `test`.
+
+**Examples:**
+```
+fix(hero): correct video play-button positioning
+
+The absolute-positioned play button used `top` instead of
+`inset-block-start`, breaking centering on the child-theme hero.
+
+Closes #48
+```
+```
+chore(build): remove dead gulp-imagemin task from parent theme
+```
+
+**Rules:**
+- Imperative mood: "add" not "added", "fix" not "fixed".
+- Reference the GitHub issue (`Closes #N`) when one exists — auto-closes on merge.
+- Don't pad — if one line says it all, that's fine.
+- **No `Co-Authored-By` trailer and no AI-attribution line.** Commits reflect the human author only.
+
+## 7. Commit
+
+```bash
+git commit -m "$(cat <<'EOF'
+fix(scope): your message here
+
+Closes #N
+EOF
+)"
+```
+
+## 8. Push the branch
+
+```bash
+git push -u origin HEAD
+```
+
+## 9. Open a PR
+
+**Invoke `/ftf-open-pr`** to compose the PR title + structured four-section body and open it via `gh pr create`. `master` is the deployed branch, so treat the merge as going live — a clear PR body makes review fast.
+
+> A PR review-comment skill (`/ftf-review-pr`) is a planned Tier-2 addition. Until it exists, address any human review feedback directly, then re-run the relevant parts of step 2 (rebuild) and step 4 (hostile read) before pushing the fix.
+
+## What NOT to do
+
+- Don't push directly to `master`.
+- Don't commit `.env`, `node_modules`, `*.map`, `*.sql`, or uploads (all gitignored — but never force-add them).
+- Don't ship a SCSS/JS source change without rebuilding and staging `dist` — the live site serves compiled assets.
+- Don't edit the parent theme for portfolio-specific work when a child-theme override is the correct place.
+- Don't amend a commit that's already been pushed — create a new commit instead.
+
+## Output
+
+When complete, report back:
+- **Branch**: the branch name
+- **Commit SHA**: the short SHA of the new commit
+- **PR URL**: the GitHub PR URL (if created)
+- **Build result**: which theme(s) rebuilt and that the build was clean (or "no rebuild needed")
+- **Assets staged**: which `dist` files were committed (or "none — no source change")

--- a/.claude/skills/ftf-commit-feature/SKILL.md
+++ b/.claude/skills/ftf-commit-feature/SKILL.md
@@ -39,7 +39,8 @@ npm --prefix wp-content/themes/fivetwofive-theme-child run build
 ```
 
 - Run from the host, not inside a container (native Gulp toolchain).
-- **ESLint does not fail the build.** The parent's gulp `lint` task runs `eslint({fix:true})` then only logs warning/error counts (`gulpfile.js` lines 47–60 — no `eslint.failAfterError()`), and `build` is `series(styles, series(lint, scripts))`. So `npm run build` exits 0 even with lint errors — **read the build output** for `Total Errors: N` and fix any before committing; don't treat a zero exit code as lint-clean. Because `fix:true` autofixes in place, the build can also modify source — re-check `git status` afterward.
+- **First-time setup (parent theme):** the parent build does `require('./gulpfile-config')`, and `gulpfile-config.js` is gitignored — only `gulpfile-config-sample.js` is tracked. On a fresh checkout copy it first or the build throws before compiling anything: `cp wp-content/themes/fivetwofive-theme/gulpfile-config-sample.js wp-content/themes/fivetwofive-theme/gulpfile-config.js`. (The child theme similarly needs `.env` from `.env.example`.)
+- **The build never hard-fails — exit code 0 does not mean success.** Every stage logs its errors and continues: styles use `sass().on('error', sass.logError)`, scripts use `uglify().on('error', …log)`, and `lint` runs `eslint({fix:true})` then only logs counts (no `eslint.failAfterError()`). So `npm run build` exits 0 even on a **Sass compile error** (→ stale `dist` CSS), a **JS minify error**, or **ESLint errors**. **Read the full build output** and scan for Sass errors, uglify errors, and ESLint `Total Errors: N` — fix any before committing. (`eslint fix:true` autofixes in place, so re-check `git status` after.)
 - The regenerated `assets/dist/` CSS/JS **must be committed** (step 5). Source maps are **not** uniformly ignored — the parent theme tracks 15 `.map` files under `assets/dist/maps/` (a `*.map` ignore rule can't hide already-tracked files), so a parent rebuild regenerates them and they appear in `git status`; stage them with the rest of the dist output. The child theme has no tracked maps — leave those. Let `git status` decide; don't assume.
 - If you only touched PHP/templates (no SCSS/JS source change), no rebuild is needed — say so explicitly.
 
@@ -57,9 +58,11 @@ If both themes changed, the two builds are independent and can run as parallel s
 Before staging, read the full diff as if you were a cold reviewer seeing the change for the first time. The goal is to **find what's broken**, not confirm the implementation. There are no tests here — the hostile read *is* the safety net.
 
 ```bash
-git status
-git diff HEAD    # HEAD covers staged + unstaged; bare `git diff` misses already-staged changes
+git status        # every `??` line is a NEW file the diff below won't show
+git diff HEAD     # staged + unstaged vs HEAD — does NOT include untracked (??) files
 ```
+
+**Untracked files:** `git diff HEAD` covers tracked changes but omits brand-new (`??`) files — yet the WordPress checklist below (ABSPATH guard, escaping, enqueue) exists precisely for new files. Open and review every `??` path from `git status` directly, or run `git add -N <path>` to force it into the diff, before declaring the read clean.
 
 ### 4a. The hostile-read rules
 

--- a/.claude/skills/ftf-commit-feature/SKILL.md
+++ b/.claude/skills/ftf-commit-feature/SKILL.md
@@ -40,7 +40,7 @@ npm --prefix wp-content/themes/fivetwofive-theme-child run build
 
 - Run from the host, not inside a container (native Gulp toolchain).
 - **ESLint does not fail the build.** The parent's gulp `lint` task runs `eslint({fix:true})` then only logs warning/error counts (`gulpfile.js` lines 47–60 — no `eslint.failAfterError()`), and `build` is `series(styles, series(lint, scripts))`. So `npm run build` exits 0 even with lint errors — **read the build output** for `Total Errors: N` and fix any before committing; don't treat a zero exit code as lint-clean. Because `fix:true` autofixes in place, the build can also modify source — re-check `git status` afterward.
-- The regenerated `assets/dist/` CSS/JS **must be committed** (step 5). `*.map` files are gitignored — leave them.
+- The regenerated `assets/dist/` CSS/JS **must be committed** (step 5). Source maps are **not** uniformly ignored — the parent theme tracks 15 `.map` files under `assets/dist/maps/` (a `*.map` ignore rule can't hide already-tracked files), so a parent rebuild regenerates them and they appear in `git status`; stage them with the rest of the dist output. The child theme has no tracked maps — leave those. Let `git status` decide; don't assume.
 - If you only touched PHP/templates (no SCSS/JS source change), no rebuild is needed — say so explicitly.
 
 ### Agent Delegation
@@ -135,7 +135,7 @@ If the self-review surfaces something, fix it now — same diff, no extra commit
 
 This repo's `.gitignore` is **deny-all-then-whitelist** (`/*` then `!wp-content/...`). That flips the usual staging risk:
 
-- **The usual over-staging risk is mostly handled** — `node_modules`, `*.map`, `.env`, `*.sql`, uploads, and third-party plugins are already ignored.
+- **The usual over-staging risk is mostly handled** — `node_modules`, `.env`, `*.sql`, uploads, and third-party plugins are already ignored. (Caveat: the `*.map` rule only hides *new* maps — the parent theme's `assets/dist/maps/` are already tracked and therefore not hidden; see below.)
 - **The real risk is under-staging**: a brand-new plugin/theme dir is **silently ignored** until you add its `!wp-content/...` exception. Verify before committing:
 
   ```bash
@@ -151,7 +151,7 @@ git add wp-content/themes/fivetwofive-theme-child/assets/dist/css/style.css
 git add .gitignore   # if you added a whitelist exception
 ```
 
-Double-check you are **not** staging `.env` (child theme BrowserSync config) or `*.map` — both should already be ignored, but confirm.
+Double-check you are **not** staging `.env` (child theme BrowserSync config). For `*.map`: the parent theme's `assets/dist/maps/` are tracked, so stage those when a parent rebuild regenerates them; the child theme's maps stay ignored. Let `git status` be the source of truth, not the `*.map` rule.
 
 ## 6. Write a good commit message
 
@@ -211,7 +211,7 @@ git push -u origin HEAD
 ## What NOT to do
 
 - Don't push directly to `master`.
-- Don't commit `.env`, `node_modules`, `*.map`, `*.sql`, or uploads (all gitignored — but never force-add them).
+- Don't commit `.env`, `node_modules`, `*.sql`, or uploads (all gitignored — but never force-add them). `*.map` is the exception: the parent theme's `assets/dist/maps/` are already tracked, so commit those when a parent rebuild changes them.
 - Don't ship a SCSS/JS source change without rebuilding and staging `dist` — the live site serves compiled assets.
 - Don't edit the parent theme for portfolio-specific work when a child-theme override is the correct place.
 - Don't amend a commit that's already been pushed — create a new commit instead.

--- a/.claude/skills/ftf-commit-feature/SKILL.md
+++ b/.claude/skills/ftf-commit-feature/SKILL.md
@@ -28,15 +28,18 @@ Any of the prefixes from `/ftf-new-branch` is acceptable: `feature/`, `fix/`, `r
 The deployed site serves the **compiled** files in each theme's `assets/dist/`. If you edited SCSS or JS source and don't rebuild, the live site ships stale assets. Build **only the theme(s) you touched**:
 
 ```bash
-# Parent theme (Gulp build runs SCSS + ESLint + JS; ESLint failure fails the build)
-cd wp-content/themes/fivetwofive-theme && npm run build
+# Run from the repo root. `npm --prefix` keeps cwd at the root, so building both
+# themes can't strand you inside the first theme's directory (a bare `cd ... &&
+# cd ...` would resolve the second path relative to the first and fail).
+# Parent theme (Gulp build: SCSS + ESLint-with-autofix + JS)
+npm --prefix wp-content/themes/fivetwofive-theme run build
 
 # Child theme (SCSS + JS; bundles GSAP)
-cd wp-content/themes/fivetwofive-theme-child && npm run build
+npm --prefix wp-content/themes/fivetwofive-theme-child run build
 ```
 
 - Run from the host, not inside a container (native Gulp toolchain).
-- A clean build is the bar. If ESLint fails the parent build, fix the lint error — don't bypass it.
+- **ESLint does not fail the build.** The parent's gulp `lint` task runs `eslint({fix:true})` then only logs warning/error counts (`gulpfile.js` lines 47–60 — no `eslint.failAfterError()`), and `build` is `series(styles, series(lint, scripts))`. So `npm run build` exits 0 even with lint errors — **read the build output** for `Total Errors: N` and fix any before committing; don't treat a zero exit code as lint-clean. Because `fix:true` autofixes in place, the build can also modify source — re-check `git status` afterward.
 - The regenerated `assets/dist/` CSS/JS **must be committed** (step 5). `*.map` files are gitignored — leave them.
 - If you only touched PHP/templates (no SCSS/JS source change), no rebuild is needed — say so explicitly.
 
@@ -46,7 +49,7 @@ If both themes changed, the two builds are independent and can run as parallel s
 
 ## 3. Note on formatting / linting
 
-- **JS**: ESLint (`@wordpress/eslint-plugin`) runs automatically inside the parent theme's Gulp `build` — there's no separate command.
+- **JS**: ESLint (`@wordpress/eslint-plugin`) runs automatically inside the parent theme's Gulp `build`, but only *reports* — it does not fail the build (see step 2). Read the output and fix errors yourself.
 - **PHP**: there is no automated formatter or linter configured (no phpcs/phpcbf). Follow the WordPress PHP Coding Standards by hand and match surrounding code. See `.cursor/rules/wordpress-developer-rules.mdc`.
 
 ## 4. Pre-push self-review (hostile read with enumeration)
@@ -55,7 +58,7 @@ Before staging, read the full diff as if you were a cold reviewer seeing the cha
 
 ```bash
 git status
-git diff
+git diff HEAD    # HEAD covers staged + unstaged; bare `git diff` misses already-staged changes
 ```
 
 ### 4a. The hostile-read rules

--- a/.claude/skills/ftf-new-branch/SKILL.md
+++ b/.claude/skills/ftf-new-branch/SKILL.md
@@ -18,11 +18,12 @@ Before any code changes are made, ensure work is happening on a clean, properly-
 
 ## Steps
 
-1. **Check the current branch**
+1. **Check the current branch and working tree**
    ```bash
    git branch --show-current
+   git status --short
    ```
-   If already on a non-`master` branch, confirm with the user before proceeding — they may want a fresh branch anyway.
+   If already on a non-`master` branch, confirm with the user before proceeding — they may want a fresh branch anyway. If `git status --short` is non-empty (uncommitted or staged changes), **stop and ask** the user before continuing — the `git checkout master` in step 2 would otherwise carry those edits onto the base branch (or fail), mixing the previous task into the next one. Don't stash or discard automatically (same rule as `/ftf-sync-master`).
 
 2. **Switch to master and pull latest (fast-forward only)**
    ```bash

--- a/.claude/skills/ftf-new-branch/SKILL.md
+++ b/.claude/skills/ftf-new-branch/SKILL.md
@@ -27,9 +27,10 @@ Before any code changes are made, ensure work is happening on a clean, properly-
 
 2. **Switch to master and pull latest (fast-forward only)**
    ```bash
-   git checkout master && git pull --ff-only
+   git checkout master && git fetch origin && git pull --ff-only
+   git rev-list --left-right --count origin/master...master   # want "0 0"
    ```
-   Always branch from an up-to-date `master`. Never branch from another working branch. `--ff-only` aborts instead of silently creating a merge commit if `master` has diverged from `origin/master`; if it refuses, stop and surface the divergence to the user — `master` should never be in that state.
+   Always branch from an up-to-date `master`. Never branch from another working branch. `--ff-only` aborts instead of silently creating a merge commit if `master` has diverged; if it refuses, stop and surface the divergence. **But `--ff-only` does not catch the ahead-only case** — if local `master` has a stray commit not on `origin/master` and the remote has nothing newer, the pull is a no-op and you'd branch off that stray commit. The `rev-list` check makes it explicit: the two numbers are how many commits `origin/master` is ahead / local `master` is ahead. Anything but `0 0` (especially a non-zero second number) means stop and surface — `master` should never be ahead of `origin/master`.
 
    > If you just merged a PR, are coming off a stale local branch, or are unsure
    > whether `master` is clean, invoke `/ftf-sync-master` first. It pulls latest,

--- a/.claude/skills/ftf-new-branch/SKILL.md
+++ b/.claude/skills/ftf-new-branch/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: ftf-new-branch
+description: >
+  Creates a properly-named git branch before starting any new work on the
+  FiveTwoFive WordPress site. Use this skill at the start of every coding
+  session, feature, bug fix, or task. Trigger whenever the user mentions
+  starting something new, working on an issue, fixing a bug, or any time work
+  is about to begin and no feature branch has been created yet. If the user
+  jumps straight into making changes without creating a branch first, pause and
+  run this skill before proceeding. Phrases like "let's work on X", "can you
+  fix Y", "start on issue #Z", or "I want to add A" are all signals to run this
+  skill first.
+---
+
+# New Branch — FiveTwoFive
+
+Before any code changes are made, ensure work is happening on a clean, properly-named branch off `master`.
+
+## Steps
+
+1. **Check the current branch**
+   ```bash
+   git branch --show-current
+   ```
+   If already on a non-`master` branch, confirm with the user before proceeding — they may want a fresh branch anyway.
+
+2. **Switch to master and pull latest (fast-forward only)**
+   ```bash
+   git checkout master && git pull --ff-only
+   ```
+   Always branch from an up-to-date `master`. Never branch from another working branch. `--ff-only` aborts instead of silently creating a merge commit if `master` has diverged from `origin/master`; if it refuses, stop and surface the divergence to the user — `master` should never be in that state.
+
+   > If you just merged a PR, are coming off a stale local branch, or are unsure
+   > whether `master` is clean, invoke `/ftf-sync-master` first. It pulls latest,
+   > prunes remote-tracking refs (including merged Dependabot branches), and
+   > (with confirmation) deletes merged local branches before you create the next one.
+
+3. **Determine the branch prefix from the work type**
+
+   Match the prefix to what the resulting commit type will be (mirrors conventional-commits practice and keeps the branch name aligned with the eventual PR):
+
+   | Prefix | When to use |
+   |---|---|
+   | `feature/` | New functionality — a new module template, plugin, CPT, ACF field group, page section |
+   | `fix/` | Bug fixes, regressions, broken behavior |
+   | `refactor/` | Code restructure with no behavior change (renames, moves, extractions) |
+   | `docs/` | Documentation-only changes (`docs/`, `readme.md`, `change-log.md`, code comments) |
+   | `chore/` | Tooling, dependencies, Gulp/build config, skills, `.cursor` rules, generated assets |
+   | `review/` | Standalone review or QA passes (e.g. `review/qa-hero-module`) |
+
+   The repo's history also uses `cleanup/` for multi-step removal work (e.g. `cleanup/phase-1-dead-plugins`); treat it as a flavor of `chore/`/`refactor/`. When in doubt between `feature/` and `fix/`: new user-observable behavior is `feature/`; making existing behavior correct is `fix/`.
+
+4. **Determine the branch name**
+   - If a GitHub issue number is known: `<prefix>/[issue-number]-[short-description]`
+   - If no issue number: `<prefix>/[short-description]`
+   - Use lowercase, hyphens only, keep it under 50 characters
+   - Examples:
+     - `feature/contact-form-plugin`
+     - `fix/hero-video-play-button`
+     - `refactor/extract-module-template-loader`
+     - `docs/parent-theme-readme`
+     - `chore/claude-skills-tier1`
+     - `review/qa-resources-module`
+
+5. **Create and switch to the branch**
+   The full branch name from step 4 already includes the prefix, so pass it directly to `git checkout -b`:
+
+   ```bash
+   git checkout -b <full-branch-name>
+   ```
+
+   Concrete example matching step 4:
+
+   ```bash
+   git checkout -b feature/contact-form-plugin
+   ```
+
+6. **Confirm to the user**
+   State the branch name and that it's ready to go. Then proceed with the work.
+
+## Important Rules
+
+- **Never commit directly to `master`** — `master` is the repo's default and deployed branch. All work lands via PRs.
+- **Always pull latest `master` first** — avoids conflicts and ensures the branch starts from the current state of the live site.
+- **One branch per issue or feature** — don't stack unrelated changes on the same branch.
+- **Branch prefix should match the eventual commit prefix** — a branch named `feature/foo` whose commit message starts with `fix:` is a smell; pick the right prefix up-front.
+
+## Output
+
+When complete, report back:
+- **Branch name**: the full branch name created
+- **Base commit**: the short SHA of the `master` commit branched from
+- **Status**: `ready` or `error` with details

--- a/.claude/skills/ftf-open-pr/SKILL.md
+++ b/.claude/skills/ftf-open-pr/SKILL.md
@@ -105,7 +105,7 @@ Checkbox-formatted list of what was verified. There is no CI, so every box is so
 ```markdown
 ## Test plan
 
-- [x] `cd wp-content/themes/<theme> && npm run build` — built clean (Gulp runs ESLint as part of build)
+- [x] `npm --prefix wp-content/themes/<theme> run build` — rebuilt; checked output for ESLint `Total Errors` (build doesn't fail on lint)
 - [x] Committed regenerated `assets/dist/` (CSS/JS; `.map` files stay gitignored)
 - [x] Manual smoke in LocalWP: loaded <affected page/template>, verified <behavior>
 - [x] Checked `wp-content/debug.log` — no new PHP notices/warnings

--- a/.claude/skills/ftf-open-pr/SKILL.md
+++ b/.claude/skills/ftf-open-pr/SKILL.md
@@ -18,7 +18,7 @@ Opens a pull request with a body that's actually scannable in code review. The p
 ## Prerequisites
 
 - You are on a non-`master` working branch (any of the prefixes from `/ftf-new-branch`) — confirm with `git branch --show-current`
-- The branch has been pushed to origin — confirm with `git status` (should say "Your branch is up to date with 'origin/<branch>'")
+- The branch has been pushed to origin **and the working tree is clean** — confirm `git status --short` is **empty** *and* `git status` says "Your branch is up to date with 'origin/<branch>'". The "up to date" line only compares committed history to upstream; it still prints when the tree has uncommitted/dirty files (e.g. a rebuilt asset or a missed new file), so a non-empty `git status --short` means work would be silently omitted from the PR — commit or revert it first.
 - Affected theme assets were rebuilt and committed, and the change was smoke-tested locally (see `/ftf-commit-feature`). There is no CI on this repo — verification is manual and on you.
 
 If any of these are not true, stop and resolve them first. Don't open a PR for unpushed code or against an unverified branch.

--- a/.claude/skills/ftf-open-pr/SKILL.md
+++ b/.claude/skills/ftf-open-pr/SKILL.md
@@ -106,7 +106,7 @@ Checkbox-formatted list of what was verified. There is no CI, so every box is so
 ## Test plan
 
 - [x] `npm --prefix wp-content/themes/<theme> run build` — rebuilt; checked output for ESLint `Total Errors` (build doesn't fail on lint)
-- [x] Committed regenerated `assets/dist/` (CSS/JS; `.map` files stay gitignored)
+- [x] Committed regenerated `assets/dist/` (CSS/JS + the parent theme's tracked `assets/dist/maps/`; child-theme maps stay ignored)
 - [x] Manual smoke in LocalWP: loaded <affected page/template>, verified <behavior>
 - [x] Checked `wp-content/debug.log` — no new PHP notices/warnings
 ```

--- a/.claude/skills/ftf-open-pr/SKILL.md
+++ b/.claude/skills/ftf-open-pr/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: ftf-open-pr
+description: >
+  Opens a GitHub pull request for the FiveTwoFive WordPress site with a
+  structured, reviewable body. Use this skill whenever the user says "open a
+  PR", "create the PR", "push and open a PR", "ship it", or anytime work is
+  committed and pushed to a working branch but the PR hasn't been opened yet.
+  Also invoke automatically as the final step of `/ftf-commit-feature` after a
+  successful push. Produces a PR description in the standard four-section shape
+  (Summary / Decisions baked in / Test plan / Follow-ups) with checkbox-formatted
+  verification steps.
+---
+
+# Open PR — FiveTwoFive
+
+Opens a pull request with a body that's actually scannable in code review. The point of the structure isn't to fill a template — it's to give a reviewer enough context to evaluate the change without re-deriving the design decisions or guessing what was tested. Repo: `jaballer/fivetwofive-cw`, base branch `master`.
+
+## Prerequisites
+
+- You are on a non-`master` working branch (any of the prefixes from `/ftf-new-branch`) — confirm with `git branch --show-current`
+- The branch has been pushed to origin — confirm with `git status` (should say "Your branch is up to date with 'origin/<branch>'")
+- Affected theme assets were rebuilt and committed, and the change was smoke-tested locally (see `/ftf-commit-feature`). There is no CI on this repo — verification is manual and on you.
+
+If any of these are not true, stop and resolve them first. Don't open a PR for unpushed code or against an unverified branch.
+
+## Step 1: Gather context for the PR body
+
+Run these in parallel (they're independent):
+
+```bash
+# What changed since master
+git log master..HEAD --oneline
+git diff master...HEAD --stat
+
+# Recent PRs for title-style reference
+gh pr list --repo jaballer/fivetwofive-cw --state all --limit 5
+
+# Issue this PR closes (if any) — look for "Closes #N" in commits or an issue number in the branch name
+```
+
+If the branch name is like `feature/42-contact-form-plugin`, the issue number is `42`. Confirm with the user if it's ambiguous.
+
+## Step 2: Compose the PR title
+
+Recent history on this repo is mixed — some titles are conventional-commits style (`chore: Remove dead gulp-imagemin task (#55)`), some are plain sentences (`Phase 3: Remove Font Awesome and replace Fancybox with GLightbox`). **Prefer the conventional-commits form** for consistency with the branch prefix:
+
+```
+<type>(<scope>): <short imperative description> (#<issue-number>)
+```
+
+- **Type** matches the branch prefix:
+
+  | Branch prefix | PR title type |
+  |---|---|
+  | `feature/` | `feat` |
+  | `fix/` | `fix` |
+  | `refactor/` | `refactor` |
+  | `docs/` | `docs` |
+  | `chore/` / `cleanup/` | `chore` |
+  | `review/` | `chore` (default — override to the dominant category if the work is all one type) |
+
+- **Scope** is optional but helpful — the area touched: `theme`, `child-theme`, `cta`, `work-cpt`, `hero`, `build`, `acf`, etc. Match what `gh pr list` shows for similar changes.
+- **Description** is imperative present tense, under 70 characters total
+- **Issue number** parenthesized at the end if there's an associated issue
+
+Examples (this repo's actual history, normalized):
+- `fix(hero): correct video play-button positioning typo (#48)`
+- `chore(build): remove dead gulp-imagemin task from parent theme (#55)`
+- `refactor(theme): remove jQuery dependency from parent theme (#47)`
+- `docs(contact-form): add plugin scope doc (#56)`
+
+## Step 3: Compose the PR body using the four-section template
+
+The body has exactly four sections in this order. Skip a section only if it would be empty.
+
+### Section 1 — Summary
+
+3–5 bullets describing the change. Reviewer-facing: what this PR makes happen, not how. Lead with the outcome, not the mechanism.
+
+```markdown
+## Summary
+
+- Bullet 1: the headline change
+- Bullet 2: the supporting changes that enable it
+- Bullet 3: any breaking-ish or surprising side effects
+```
+
+### Section 2 — Decisions baked in
+
+This is the section reviewers most want and that PR templates almost never include. List the design choices made during implementation that aren't obvious from the code, with the alternative considered. Lock-in the rationale so the next reviewer (or your future self) doesn't re-litigate it.
+
+```markdown
+## Decisions baked in
+
+- **Choice A over B** because [reason]. [Optional: when this would change.]
+- **Pattern X used here** because [reason], matches the precedent set in [file/PR].
+```
+
+Common FiveTwoFive decisions worth recording: child-theme override vs. parent-theme change; new first-party plugin vs. theme code; shortcode vs. ACF module wrapper; build-tool/dependency choices. If there genuinely were no design decisions to call out (e.g. a typo fix), omit this section.
+
+### Section 3 — Test plan
+
+Checkbox-formatted list of what was verified. There is no CI, so every box is something you actually did locally. Include the actual commands and the manual steps.
+
+```markdown
+## Test plan
+
+- [x] `cd wp-content/themes/<theme> && npm run build` — built clean (Gulp runs ESLint as part of build)
+- [x] Committed regenerated `assets/dist/` (CSS/JS; `.map` files stay gitignored)
+- [x] Manual smoke in LocalWP: loaded <affected page/template>, verified <behavior>
+- [x] Checked `wp-content/debug.log` — no new PHP notices/warnings
+```
+
+> Check a box only for what you actually ran. For UI / template / styling work, state explicitly that visual verification was manual — reviewers should know what was vs wasn't checked. Never claim a smoke test you didn't perform.
+
+### Section 4 — Follow-ups (optional)
+
+Any issues filed, deferred work, or known limitations the reviewer should be aware of. Only include if there's real follow-up; don't pad.
+
+```markdown
+## Follow-ups
+
+- [#NNN](https://github.com/jaballer/fivetwofive-cw/issues/NNN) — <short description>
+- Out of scope here, would need <design-call>: <future work>
+```
+
+## Step 4: Open the PR
+
+Use a heredoc for the body so newlines and special chars survive:
+
+```bash
+gh pr create --repo jaballer/fivetwofive-cw --base master \
+  --title "<type>(<scope>): <description> (#<issue-number>)" --body "$(cat <<'EOF'
+## Summary
+
+- ...
+
+## Decisions baked in
+
+- **...** because ...
+
+## Test plan
+
+- [x] ...
+
+## Follow-ups
+
+- ...
+EOF
+)"
+```
+
+If `gh pr create` reports the PR already exists for this branch, switch to `gh pr edit <pr-number> --body "$(cat <<'EOF' ... EOF
+)"`.
+
+## Important rules
+
+- **No AI-attribution footer or trailer.** Do not add "🤖 Generated with Claude Code" (or any similar generated-by line) to the PR body, and no `Co-Authored-By` trailer in the commits. PRs and commits reflect the human author only.
+- **Don't fabricate test results.** If a smoke test or build wasn't run, don't claim it was. Leave the box unchecked or omit the line.
+- **Don't pad the body.** A four-line summary on a one-line change is worse than no body. Each section is optional except Summary.
+- **Don't put emojis in the title** — they break `gh` CLI URL encoding sometimes and the project's history doesn't use them.
+- **Include `Closes #N` in the PR body** when the PR resolves an issue — only the closing-keyword form (`Closes #N`, `Fixes #N`, `Resolves #N`) in the body or a commit message triggers GitHub's auto-close on merge. The `(#N)` suffix in the title is human-readable cross-referencing only and does **not** auto-close.
+
+## Output
+
+When complete, report back:
+- **PR URL**: the GitHub PR URL
+- **Title**: the PR title used
+- **Body sections included**: which of the four sections made it in
+- **Closes**: the issue number this PR closes, if any

--- a/.claude/skills/ftf-sync-master/SKILL.md
+++ b/.claude/skills/ftf-sync-master/SKILL.md
@@ -67,28 +67,25 @@ Get back to a known-good baseline on `master` so the next task starts from a cle
 
    ```bash
    git pull --ff-only
+   git rev-list --left-right --count origin/master...master   # want "0 0"
    ```
 
-   `--ff-only` aborts instead of creating a merge commit when the branch can't be fast-forwarded. If the pull refuses to fast-forward, stop and surface the situation to the user — `master` should never have local commits ahead of `origin/master`. Plain `git pull` would silently merge here, which violates this skill's whole point of surfacing divergence.
+   `--ff-only` aborts instead of creating a merge commit when the branch can't be fast-forwarded; if it refuses, stop and surface — plain `git pull` would silently merge here, defeating this skill's purpose. **But `--ff-only` is a no-op in the ahead-only case** — if local `master` has a stray commit not on `origin/master` and the remote has nothing newer, the pull succeeds silently and that stray commit becomes the baseline for every future branch. The `rev-list` check makes it explicit: the second number is how many commits local `master` is ahead of the remote; anything but `0 0` means stop and surface — `master` should never be ahead of `origin/master`. (Mirrors the same check in `/ftf-new-branch` step 2.)
 
 5. **Identify safe-to-delete merged local branches**
 
-   ```bash
-   git branch --merged master
-   ```
+   Don't gather candidates from `git branch --merged master` alone — GitHub's **squash-merge** default rewrites history, so a squash-merged branch's tip is never reachable from `master` and `--merged` silently *excludes* it (see the squash-merge note in step 6). Relying on `--merged` would mean squash-merged branches are never even considered for cleanup — and on a repo with Dependabot, most merges are squashes. `--merged` also *over*-includes: a tip can be reachable without its PR ever being merged (cherry-picks, manual rebases, never-PR'd branches). So reachability is neither necessary nor sufficient.
 
-   `git branch --merged master` only checks reachability — a branch's tip can be in `master`'s history without its PR ever being merged (cherry-picks, manual rebases, true-merge PRs of unrelated work, branches that were never PR'd). The "tip is in master" signal is necessary but not sufficient for safe deletion.
-
-   For each candidate, verify a merged PR exists before adding it to the delete list:
+   Treat **"has a merged PR"** as the real signal. Enumerate every local branch except `master` and the current branch, and check each:
 
    ```bash
-   gh pr list --state merged --head <branch-name> --json number,mergedAt --limit 1
+   git branch --format='%(refname:short)' | grep -vx master   # all local branches to test
+   # for each <branch-name>:
+   gh pr list --state merged --head <branch-name> --json number,mergedAt,headRefOid --limit 1
    ```
 
-   - **Branch + verified merged PR** → safe to propose for deletion in step 6
-   - **Branch with no merged PR** (open PR, no PR, or only closed-without-merge) → leave alone. Surface separately as "master-reachable tip but unverified PR status — not proposing deletion." This applies to the starting branch from step 2 as well.
-
-   Filter out `master` itself unconditionally.
+   - **Merged PR exists** → candidate for deletion; carry it to step 6 (which picks `-d` vs the squash-merge `-D` path via the SHA check).
+   - **No merged PR** (open PR, no PR, or closed-without-merge) → leave alone. Surface separately as "unverified PR status — not proposing deletion." This applies to the starting branch from step 2 as well.
 
 6. **Confirm before deleting stale branches**
 
@@ -100,9 +97,9 @@ Get back to a known-good baseline on `master` so the next task starts from a cle
    git branch -d <branch-name>
    ```
 
-   Use `-d` (safe), not `-D`. If `-d` refuses to delete, that branch isn't actually merged — surface the warning instead of force-deleting.
+   Use `-d` (safe), not `-D`. `-d` succeeds for true-merged branches. If `-d` refuses ("not fully merged") on a candidate that step 5 confirmed has a merged PR, the branch was **squash-merged** (its tip isn't reachable from master) — don't force-delete blindly; drop to the SHA check below.
 
-   **Squash-merge exception:** GitHub's squash-merge default produces branches whose tip is NOT reachable from master even after the PR is confirmed merged. In that case `git branch --merged master` won't list the branch and `git branch -d` will refuse to delete it ("not fully merged"). When `gh pr list --state merged --head <branch>` returns a merged PR but `-d` refuses, a SHA check is required before offering `-D` — `--head` filters by branch *name* only, so a reused name can match an unrelated older merged PR and the force-delete could destroy unmerged work.
+   **Squash-merge exception:** GitHub's squash-merge default produces branches whose tip is NOT reachable from master even after the PR is confirmed merged. In that case `git branch --merged master` won't list the branch (which is why step 5 gathers candidates by merged-PR state, not `--merged`) and `git branch -d` will refuse to delete it ("not fully merged"). When `gh pr list --state merged --head <branch>` returns a merged PR but `-d` refuses, a SHA check is required before offering `-D` — `--head` filters by branch *name* only, so a reused name can match an unrelated older merged PR and the force-delete could destroy unmerged work.
 
    ```bash
    pr_head_oid=$(gh pr list --state merged --head <branch> --json headRefOid --limit 1 | jq -r '.[0].headRefOid')

--- a/.claude/skills/ftf-sync-master/SKILL.md
+++ b/.claude/skills/ftf-sync-master/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: ftf-sync-master
+description: >
+  Returns the local FiveTwoFive repo to a verifiably clean state on the latest
+  `master` before starting the next task. Use after a PR is merged, when
+  switching context between tasks, or any time you want to confirm `master` is
+  up to date and stale local branches are cleaned up. Trigger phrases include
+  "sync master", "clean up", "back to master", "fresh start", "start the next
+  thing", "we just deployed", "PR is merged what's next", or any signal that
+  the previous unit of work is finished and a new one is about to begin. This
+  skill does NOT create a branch — chain to `/ftf-new-branch` when ready to
+  start work.
+---
+
+# Sync Master — FiveTwoFive
+
+Get back to a known-good baseline on `master` so the next task starts from a clean slate.
+
+## When to use
+
+- A PR was just merged
+- Switching context between unrelated tasks
+- Start of a new session after the previous one ended on a feature branch
+- Any time the local state of `master` and merged feature branches is uncertain
+- After merging a batch of Dependabot PRs — their remote-tracking refs pile up and want pruning
+
+## When NOT to use
+
+- Mid-task on an active feature branch — this skill switches to `master` and may delete the current branch if its PR is merged. Finish or stash work first.
+- As a substitute for `/ftf-new-branch` — this skill never creates a branch.
+
+## Steps
+
+1. **Check working tree state**
+
+   ```bash
+   git status --short
+   ```
+
+   If output is non-empty (uncommitted, staged, or untracked changes), surface what's there and ask the user before continuing. Do not silently stash or discard.
+
+2. **Note the starting branch and verify its PR status**
+
+   ```bash
+   git branch --show-current
+   ```
+
+   - If on `master`: skip the verification step and proceed to step 3.
+   - If on any other branch: check whether its PR is merged before this skill considers the branch safe to delete later.
+
+     ```bash
+     gh pr list --state merged --head <branch-name> --json number,mergedAt,title --limit 1
+     ```
+
+     If the PR is unmerged or there is no PR for the branch, treat the branch as **active work** — switch to `master` for the sync but do **not** propose deleting it.
+
+3. **Switch to master and fetch with prune**
+
+   ```bash
+   git checkout master
+   git fetch --prune
+   ```
+
+   `--prune` removes remote-tracking refs (`origin/branch-foo`) for branches deleted on GitHub after merge. On this repo that clears the `origin/dependabot/*` refs left behind by merged dependency bumps.
+
+4. **Pull latest master (fast-forward only)**
+
+   ```bash
+   git pull --ff-only
+   ```
+
+   `--ff-only` aborts instead of creating a merge commit when the branch can't be fast-forwarded. If the pull refuses to fast-forward, stop and surface the situation to the user — `master` should never have local commits ahead of `origin/master`. Plain `git pull` would silently merge here, which violates this skill's whole point of surfacing divergence.
+
+5. **Identify safe-to-delete merged local branches**
+
+   ```bash
+   git branch --merged master
+   ```
+
+   `git branch --merged master` only checks reachability — a branch's tip can be in `master`'s history without its PR ever being merged (cherry-picks, manual rebases, true-merge PRs of unrelated work, branches that were never PR'd). The "tip is in master" signal is necessary but not sufficient for safe deletion.
+
+   For each candidate, verify a merged PR exists before adding it to the delete list:
+
+   ```bash
+   gh pr list --state merged --head <branch-name> --json number,mergedAt --limit 1
+   ```
+
+   - **Branch + verified merged PR** → safe to propose for deletion in step 6
+   - **Branch with no merged PR** (open PR, no PR, or only closed-without-merge) → leave alone. Surface separately as "master-reachable tip but unverified PR status — not proposing deletion." This applies to the starting branch from step 2 as well.
+
+   Filter out `master` itself unconditionally.
+
+6. **Confirm before deleting stale branches**
+
+   List the stale branches to the user with short context (last commit subject + age) and ask for confirmation **before** deleting anything. Default to a single confirm-all prompt; only ask per-branch if the list is suspicious or the user has previously asked for granular control.
+
+   On confirmation:
+
+   ```bash
+   git branch -d <branch-name>
+   ```
+
+   Use `-d` (safe), not `-D`. If `-d` refuses to delete, that branch isn't actually merged — surface the warning instead of force-deleting.
+
+   **Squash-merge exception:** GitHub's squash-merge default produces branches whose tip is NOT reachable from master even after the PR is confirmed merged. In that case `git branch --merged master` won't list the branch and `git branch -d` will refuse to delete it ("not fully merged"). When `gh pr list --state merged --head <branch>` returns a merged PR but `-d` refuses, a SHA check is required before offering `-D` — `--head` filters by branch *name* only, so a reused name can match an unrelated older merged PR and the force-delete could destroy unmerged work.
+
+   ```bash
+   pr_head_oid=$(gh pr list --state merged --head <branch> --json headRefOid --limit 1 | jq -r '.[0].headRefOid')
+   branch_tip=$(git rev-parse <branch>)
+
+   if [ "$pr_head_oid" = "$branch_tip" ]; then
+       # Tips match — branch hasn't moved since the squash-merge. Force-delete is recoverable from reflog if needed.
+       # Surface: "Branch <name> was squash-merged in PR #<n>; tip unchanged since merge. Force-delete safe? (`git branch -D <name>`)"
+   else
+       # Branch has commits the merged PR doesn't include. Treat as active work.
+       # Surface: "Branch <name> shares its name with merged PR #<n>, but local tip does not match the PR's head. Not proposing deletion — treat as active work."
+   fi
+   ```
+
+   Only proceed with `-D` on explicit user confirmation AND a verified SHA match.
+
+7. **Report final state**
+
+   See **Output** below.
+
+## Important Rules
+
+- **Never auto-delete branches** — always confirm with the user.
+- **Never use `git branch -D`** unless the user explicitly requests force-delete with reason. `-d` is the safe default; if it refuses, that's a signal worth surfacing.
+- **Never stash or discard uncommitted work** automatically. If the working tree is dirty, the user decides.
+- **Never `git reset --hard master`**. If `git pull --ff-only` refuses to fast-forward, the user needs to investigate — don't paper over it.
+- **Never run `gh pr close`, `git push --delete`, or any other destructive remote operation** in this skill. This is local cleanup only.
+- **This skill does not create branches.** When ready to start the next task, invoke `/ftf-new-branch`.
+
+## Output
+
+When complete, report back:
+
+- **Starting branch**: branch the user was on when the skill ran
+- **Current branch**: should be `master`
+- **Master SHA**: short SHA of the new tip
+- **Pulled**: number of commits fast-forwarded (or "already up to date")
+- **Local branches deleted**: list, or "none"
+- **Remote refs pruned**: count from `git fetch --prune`
+- **Status**: `clean` or `warnings` with details
+- **Next**: a one-line nudge — e.g. "Ready for `/ftf-new-branch` when you have the next task."

--- a/.cursor/rules/wordpress-developer-rules.mdc
+++ b/.cursor/rules/wordpress-developer-rules.mdc
@@ -1,12 +1,13 @@
 ---
 alwaysApply: true
 ---
-# WordPress Development Rules for Blackthorn
+# WordPress Development Rules for FiveTwoFive
 
 ### Version Control
 
-- Only track changes in the silicon-child theme repository.
-- Keep edits limited to the theme — avoid modifying core, plugins, or parent theme files.
+- Version-controlled surface: the parent theme (`fivetwofive-theme`), the child theme (`fivetwofive-theme-child`), and the first-party `fivetwofive-*` plugins. Everything else (WordPress core, third-party plugins, uploads) is intentionally gitignored via the deny-all-then-whitelist `.gitignore`.
+- Make portfolio-specific changes in the **child theme** — it's the safest place to customize. Keep the **parent theme reusable**; only touch it for intentional framework-level changes. Never edit WordPress core or third-party plugins.
+- New first-party plugin or theme dir? Add its `!wp-content/...` exception to `.gitignore` first, or `git add` will silently ignore it.
 - Write clear, detailed commit messages that explain the what and why.
 - Follow consistent commit prefixes (e.g., feat, fix, docs, chore) to make history easier to scan.
 
@@ -44,10 +45,11 @@ alwaysApply: true
 
 ### Naming Conventions
 
-- Use `silicon_child_` prefix for all custom functions to avoid conflicts
-- Class names use PascalCase (e.g., `Events_Post_Type`, `Silicon_Child_ACF`)
+- Prefix custom functions to avoid conflicts: `fivetwofive_` in the parent theme, `fivetwofive_child_` in the child theme (e.g., `fivetwofive_child_enqueue_assets`)
+- Class names use PascalCase (e.g., `Events_Post_Type`, `FiveTwoFive_Child_ACF`)
 - File names use lowercase with hyphens (e.g., `event-image-helpers.php`)
-- Hook names use underscores (e.g., `silicon_child_enqueue_styles`)
+- Hook names use underscores and the same prefix (e.g., `fivetwofive_child_enqueue_assets`)
+- Custom post type / taxonomy slugs use the `ftf_` prefix (e.g., `ftf_work`, `ftf_event`)
 - CSS classes follow BEM methodology where applicable
 
 ## WordPress Best Practices

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@
 
 !.cursor/
 
+# Claude Code skills — track the skills only; keep local settings/worktrees out
+!.claude/
+.claude/*
+!.claude/skills/
+
 !wp-content
 
 wp-content/*


### PR DESCRIPTION
## Summary

- Add four `ftf-*` Claude Code skills remixed from the KrateCMS `kr8-*` set, adapted to this WordPress repo's branch → commit → PR workflow on `master`: `ftf-new-branch`, `ftf-sync-master`, `ftf-open-pr`, `ftf-commit-feature`.
- Fix `.cursor/rules/wordpress-developer-rules.mdc`, which was copied from another project and never updated (`Blackthorn` title, `silicon_child_` prefix) — and corrected the version-control bullet, which wrongly said not to track plugins/parent theme when this repo intentionally tracks both.
- Whitelist `.claude/skills/` in `.gitignore` so the deny-all-then-whitelist gitignore stops silently ignoring the skills (the new files were invisible to git until this).

## Decisions baked in

- **Build-and-commit `assets/dist/` replaces the test/format gate** because this repo has no PHPUnit/Pint/CI. The Gulp build (which runs ESLint) plus a manual smoke checklist is the real pre-push safety net, so `ftf-commit-feature` is built around it.
- **Pre-push checklist rewritten for WordPress bug classes** (output escaping, input sanitization, nonces, `ABSPATH` guard, `$wpdb->prepare`, parent-vs-child override, ACF↔`acf-json/` sync, rewrite flush, enqueue, i18n, `show_in_rest`) instead of the Laravel/tenancy classes from the source skills.
- **No AI-attribution footer/trailer** in PRs or commits — diverges deliberately from the `kr8-open-pr` source, which still carries one; this repo's authorship is human-only.
- **Whitelisted `.claude/skills/` specifically, not all of `.claude/`** so a future local `settings.local.json` / worktrees stay untracked.
- **`ftf-` prefix** to match the repo's `ftf_` / `fivetwofive` code conventions and keep slash-commands clean.

## Test plan

- [x] No asset rebuild needed — change set is skill markdown + one `.cursor` rule + `.gitignore` (no SCSS/JS/PHP touched)
- [x] All four skills register + load in the Claude Code harness; frontmatter `name:` matches each directory
- [x] Hostile-read grep: 0 `silicon`/`Blackthorn` remaining; no `kr8-`/`ddev`/`pint`/`phpunit`/`laravel` copy-leak in the skills; no AI-attribution lines beyond the rule that forbids them
- [x] `git check-ignore` confirms `.claude/skills/` is now tracked (the root `/*` rule ignored it before the whitelist)
- [x] Dogfooded: this PR was committed and opened by running `ftf-commit-feature` → `ftf-open-pr`

## Follow-ups

- Tier-2 skills planned (the skills already reference `/ftf-review-pr` as "planned"): `ftf-review-pr`, `ftf-plan-inventory`, `ftf-new-feature`, and an `ftf-session-recap` that targets the existing `.cursor/rules/session-recap-template.mdc`.