### PR TITLE
fix(cta): style title and silence fresh-install warnings (#70, #67)

### DIFF
--- a/wp-content/plugins/fivetwofive-cta/resources/assets/frontend/styles/fivetwofive-cta.css
+++ b/wp-content/plugins/fivetwofive-cta/resources/assets/frontend/styles/fivetwofive-cta.css
@@ -25,7 +25,7 @@
     margin: 0 0 15px 0;
 }
 
-.fta-cta__content p:last-child {
+.ftf-cta__content p:last-child {
     margin: 0;
 }
 

--- a/wp-content/plugins/fivetwofive-cta/resources/views/frontend/fivetwofive-cta-shortcode.php
+++ b/wp-content/plugins/fivetwofive-cta/resources/views/frontend/fivetwofive-cta-shortcode.php
@@ -20,10 +20,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<div class="ftf-cta__column-1">
 
 			<?php if ( ! empty( $cta_title ) ) : ?>
-				<h2 class="fta-cta__title mb-2" style="<?php echo $cta_title_style; ?>"><?php echo esc_html( $cta_title ); ?></h2>
+				<h2 class="ftf-cta__title mb-2" style="<?php echo $cta_title_style; ?>"><?php echo esc_html( $cta_title ); ?></h2>
 			<?php endif; ?>
 
-			<div class="fta-cta__content" style="<?php echo $cta_message_style; ?>">
+			<div class="ftf-cta__content" style="<?php echo $cta_message_style; ?>">
 				<?php
 				if ( ! empty( $cta_message ) ) :
 					echo wp_kses_post( $cta_message );

--- a/wp-content/plugins/fivetwofive-cta/src/Admin/Settings.php
+++ b/wp-content/plugins/fivetwofive-cta/src/Admin/Settings.php
@@ -334,7 +334,7 @@ class Settings {
 		}
 
 		$radio_options = $this->options_radio();
-		if ( ! array_key_exists( $input['cta_button_target'], $radio_options ) || ! isset( $input['cta_button_target'] ) ) {
+		if ( ! isset( $input['cta_button_target'] ) || ! array_key_exists( $input['cta_button_target'], $radio_options ) ) {
 			$input['cta_button_target'] = null;
 		} else {
 			$input['cta_button_target'] = sanitize_text_field( $input['cta_button_target'] );

--- a/wp-content/plugins/fivetwofive-cta/src/Frontend/Shortcode.php
+++ b/wp-content/plugins/fivetwofive-cta/src/Frontend/Shortcode.php
@@ -108,6 +108,10 @@ class Shortcode {
 
 		$options = get_option( $this->plugin_name . '_options' );
 
+		if ( ! is_array( $options ) ) {
+			$options = array();
+		}
+
 		if ( ! empty( $options['cta_title'] ) ) {
 			$cta_title = sanitize_text_field( $options['cta_title'] );
 		}
@@ -149,32 +153,31 @@ class Shortcode {
 			$cta_button_target = sanitize_text_field( $a['button_target'] );
 		}
 
-		if ( $options['cta_background_image'] ) {
+		if ( ! empty( $options['cta_background_image'] ) ) {
 			$cta_style .= sprintf( 'background-image:url(\'%1$s\');', esc_url( wp_get_attachment_image_url( $options['cta_background_image'], 'full' ) ) );
 		}
 
-		if ( $options['cta_background_color'] ) {
+		if ( ! empty( $options['cta_background_color'] ) ) {
 			$cta_style .= sprintf( 'background-color:%1$s;', esc_attr( $options['cta_background_color'] ) );
 		}
 
-		if ( $options['cta_text_alignment'] ) {
+		if ( ! empty( $options['cta_text_alignment'] ) ) {
 			$cta_style .= sprintf( 'text-align:%1$s;', esc_attr( $options['cta_text_alignment'] ) );
 		}
 
-		if ( $options['cta_title_color'] ) {
+		if ( ! empty( $options['cta_title_color'] ) ) {
 			$cta_title_style .= sprintf( 'color:%1$s;', esc_attr( $options['cta_title_color'] ) );
 		}
 
-		if ( $options['cta_message_color'] ) {
+		if ( ! empty( $options['cta_message_color'] ) ) {
 			$cta_message_style .= sprintf( 'color:%1$s;', esc_attr( $options['cta_message_color'] ) );
 		}
 
-
-		if ( $options['cta_button_text_color'] ) {
+		if ( ! empty( $options['cta_button_text_color'] ) ) {
 			$cta_button_style .= sprintf( 'color:%1$s;', esc_attr( $options['cta_button_text_color'] ) );
 		}
 
-		if ( $options['cta_button_background_color'] ) {
+		if ( ! empty( $options['cta_button_background_color'] ) ) {
 			$cta_button_style .= sprintf( 'background-color:%1$s;border-color:%1$s;', esc_attr( $options['cta_button_background_color'] ) );
 		}
 


### PR DESCRIPTION
## Summary

- **CTA title now renders styled** — the markup emitted `.fta-cta__title`, which never matched the stylesheet's `.ftf-cta__title`, so the title showed with no styles. (Closes #70)
- **No more PHP warnings before settings are saved** — the `[fivetwofive_cta]` shortcode read the options array without guarding for the unsaved (non-array) case, warning on every style lookup. (Closes #67)
- Normalized the `.fta-cta__content` twin (typo'd identically in both the view and the CSS) so the two can't drift if someone later "fixes" only one side.
- Reordered the `sanitize_fields()` radio guard so `isset()` short-circuits before the key is dereferenced in `array_key_exists()`.

## Decisions baked in

- **Coerce the front-end options read to `array()`** rather than leaning on the registered default — `register_settings()` only runs on `admin_init`, so the default never applies on the front end (the exact reason a fresh install warned). The seven style builders then switch to `! empty()`, matching the style already used by the content block directly above them.
- **Fixed `.fta-cta__content` in both the view and the CSS**, not just the title. The two were misspelled identically and "worked" only by coincidence; renaming one side alone would have silently broken message spacing.
- **Behavior on the live site is unchanged except the title.** For a saved option, `! empty()` is equivalent to the old truthy check for every real value (hex colors, alignment, URL, attachment id — none are a meaningful empty/`'0'`). The title picking up `.ftf-cta__title` is the intended, live-visible fix.
- **Scope kept tight:** inline-`style` output escaping (#72), a CHANGELOG entry, and a version bump are intentionally left out so this stays a clean two-issue fix.

## Test plan

- [x] `php -l` clean on both changed PHP files (`src/Frontend/Shortcode.php`, `src/Admin/Settings.php`)
- [x] Repo-wide grep for `fta-cta` → zero remaining references; `ftf-cta__title` / `ftf-cta__content` now match the stylesheet selectors
- [x] Confirmed the plugin has no SCSS/JS build — the CSS is hand-authored and served directly via `plugins_url()`, so there is no `dist` to rebuild
- [ ] Runtime smoke in LocalWP (drop `[fivetwofive_cta]` on a page of a fresh/unsaved install, confirm styled title + clean `debug.log`) — **not yet run; verified statically only**

## Follow-ups

- [#72](https://github.com/jaballer/fivetwofive-cw/issues/72) — escape the inline `style` attributes at output (touches the same three view lines; natural next PR in group A)
- CHANGELOG `[Unreleased]` entry + version bump — deferred; better batched at release or once more of epic [#69](https://github.com/jaballer/fivetwofive-cw/issues/69) lands