### PR TITLE
fix(cta): escape inline styles, add rel to _blank button (#71, #72)

### DIFF
--- a/wp-content/plugins/fivetwofive-cta/resources/views/frontend/fivetwofive-cta-shortcode.php
+++ b/wp-content/plugins/fivetwofive-cta/resources/views/frontend/fivetwofive-cta-shortcode.php
@@ -15,15 +15,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 
-<div class="ftf-cta" style="<?php echo $cta_style; ?>" role="complementary" aria-label="Call to action">
+<div class="ftf-cta" style="<?php echo esc_attr( $cta_style ); ?>" role="complementary" aria-label="Call to action">
 	<div class="ftf-cta__inner">
 		<div class="ftf-cta__column-1">
 
 			<?php if ( ! empty( $cta_title ) ) : ?>
-				<h2 class="ftf-cta__title mb-2" style="<?php echo $cta_title_style; ?>"><?php echo esc_html( $cta_title ); ?></h2>
+				<h2 class="ftf-cta__title mb-2" style="<?php echo esc_attr( $cta_title_style ); ?>"><?php echo esc_html( $cta_title ); ?></h2>
 			<?php endif; ?>
 
-			<div class="ftf-cta__content" style="<?php echo $cta_message_style; ?>">
+			<div class="ftf-cta__content" style="<?php echo esc_attr( $cta_message_style ); ?>">
 				<?php
 				if ( ! empty( $cta_message ) ) :
 					echo wp_kses_post( $cta_message );
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 		<?php if ( ! empty( $cta_button_text ) ) : ?>
 			<div class="ftf-cta__column-2">
-				<a class="ftf-cta__btn button" style="<?php echo $cta_button_style; ?>" href="<?php echo esc_url( $cta_button_link ); ?>" target="<?php echo esc_attr( $cta_button_target ); ?>" aria-label="<?php echo esc_attr( $cta_button_text ); ?>" role="button"><?php echo wp_kses_post( $cta_button_text ); ?></a>
+				<a class="ftf-cta__btn button" style="<?php echo esc_attr( $cta_button_style ); ?>" href="<?php echo esc_url( $cta_button_link ); ?>" target="<?php echo esc_attr( $cta_button_target ); ?>"<?php echo ( '_blank' === $cta_button_target ) ? ' rel="noopener noreferrer"' : ''; ?> aria-label="<?php echo esc_attr( $cta_button_text ); ?>" role="button"><?php echo wp_kses_post( $cta_button_text ); ?></a>
 			</div><!-- end .cta-column-2 -->
 		<?php endif; ?>
 


### PR DESCRIPTION
## Summary

- **Escape inline `style` at output** — the four `style="…"` attributes in the CTA shortcode view (`$cta_style`, `$cta_title_style`, `$cta_message_style`, `$cta_button_style`) are now wrapped in `esc_attr()`. (Closes #72)
- **`rel` on the CTA button** — emit `rel="noopener noreferrer"`, but only when the button target is `_blank`. (Closes #71)
- No visual change to existing CTAs (see below).

## Decisions baked in

- **`esc_attr()` is defense-in-depth, not a behavior change.** Each style fragment is already escaped per-value when the string is built in `Shortcode.php`. `esc_attr()` only encodes `' " < > &`; the sole affected char is the single quotes in `background-image:url('…')`, which become `&#039;` and the browser decodes back to `'` before the CSS parser runs — so every saved CTA renders byte-for-byte identically.
- **`rel` is conditional on `_blank`.** `noreferrer` on a `_self` link would needlessly strip the `Referer` header on same-tab navigation, and `noopener` is meaningless without a new browsing context — so it fires only for `_blank`.
- **Left `role="button"` on the anchor untouched** — that anchor-as-button a11y point is unrelated to #71/#72 and would be its own small issue.

## Test plan

- [x] `php -l` clean on `resources/views/frontend/fivetwofive-cta-shortcode.php`
- [x] Grep confirms no unescaped inline `style` attributes remain in the view
- [ ] Runtime smoke in LocalWP (render a CTA with a `_blank` button; confirm `rel` is present and styles render intact) — **not run this round, per request; verified statically only**

## Follow-ups

- Remaining epic [#69](https://github.com/jaballer/fivetwofive-cw/issues/69) groups still open: B (admin #73–#76), C (#77–#78), D (#79), F (#82–#83)
- Possible a11y P4 (not yet filed): drop `role="button"` + the redundant `aria-label` from the real link in this same view