### PR TITLE
fix(cta): render settings help text, remove dead admin code (#73-#76)

### DIFF
--- a/wp-content/plugins/fivetwofive-cta/resources/views/admin/settings-page.php
+++ b/wp-content/plugins/fivetwofive-cta/resources/views/admin/settings-page.php
@@ -42,12 +42,19 @@ settings_errors( 'fivetwofive_cta_messages' );
 			</ul>
 
 			<div id="ftfCtaContent">
+				<?php
+				// The tabbed layout renders fields with do_settings_fields(), which does not
+				// invoke the section description callbacks the way do_settings_sections() would.
+				// Call them here so each section's help text still renders above its fields.
+				$this->settings_content_section();
+				?>
 				<table class="form-table">
 					<?php do_settings_fields( 'fivetwofive_cta', 'fivetwofive_cta_content_section' ); ?>
 				</table>
 			</div>
 
 			<div id="ftfCtaAppearance">
+				<?php $this->settings_appearance_section(); ?>
 				<table class="form-table">
 					<?php do_settings_fields( 'fivetwofive_cta', 'fivetwofive_cta_appearance_section' ); ?>
 				</table>

--- a/wp-content/plugins/fivetwofive-cta/src/Admin/Settings.php
+++ b/wp-content/plugins/fivetwofive-cta/src/Admin/Settings.php
@@ -139,16 +139,6 @@ class Settings {
 			)
 		);
 		
-		// Add nonce field
-		add_settings_field(
-			'settings_nonce',
-			'',
-			function() {
-				wp_nonce_field('fivetwofive_cta_settings', 'fivetwofive_cta_nonce');
-			},
-			$this->plugin_name
-		);
-
 		$this->register_content_settings();
 		$this->register_appearance_settings();
 	}
@@ -520,28 +510,6 @@ class Settings {
 	}
 
 	/**
-	 * Settings API textarea field.
-	 *
-	 * Generate the textarea field needed for the settings api.
-	 *
-	 * @param array $args Fields arguments.
-	 * @return void
-	 */
-	public function field_textarea( $args ) {
-		$options = get_option( 'fivetwofive_cta_options', $this->default_settings() );
-
-		$id    = isset( $args['id'] ) ? $args['id'] : '';
-		$label = isset( $args['label'] ) ? $args['label'] : '';
-
-		$allowed_tags = wp_kses_allowed_html( 'post' );
-
-		$value = isset( $options[ $id ] ) ? wp_kses( stripslashes_deep( $options[ $id ] ), $allowed_tags ) : '';
-
-		echo '<textarea id="fivetwofive_cta_options_' . esc_attr( $id ) . '" name="fivetwofive_cta_options[' . esc_attr( $id ) . ']" rows="5" cols="50">' . wp_kses_post( $value ) . '</textarea><br />';
-		echo '<label for="fivetwofive_cta_options_' . esc_attr( $id ) . '">' . esc_html( $label ) . '</label>';
-	}
-
-	/**
 	 * Settings API radio field.
 	 *
 	 * Generate the radio field needed for the settings api.
@@ -553,8 +521,7 @@ class Settings {
 
 		$options = get_option( 'fivetwofive_cta_options', $this->default_settings() );
 
-		$id    = isset( $args['id'] ) ? $args['id'] : '';
-		$label = isset( $args['label'] ) ? $args['label'] : '';
+		$id = isset( $args['id'] ) ? $args['id'] : '';
 
 		$selected_option = isset( $options[ $id ] ) ? sanitize_text_field( $options[ $id ] ) : '';
 


### PR DESCRIPTION
## Summary

- **Settings section help text now renders** — the Content and Appearance descriptions (including the `[fivetwofive_cta]` shortcode hint) finally appear on the settings page. (Closes #73)
- **Removed the dead `fivetwofive_cta_nonce` field** — it was never rendered and never verified. (Closes #74)
- **Removed the unused `field_textarea()` method.** (Closes #75)
- **Dropped a dead `$label` assignment in `field_radio()`** that its `foreach` loop variable immediately shadowed. (Closes #76)

Net effect: `+8 / −34` — mostly dead-code removal plus the one real fix (#73).

## Decisions baked in

- **#73 calls the section callbacks directly from the template.** The tabbed layout uses `do_settings_fields()` (so it can split fields across the Content/Appearance tabs), and that function — unlike `do_settings_sections()` — never invokes the section description callbacks. Calling `$this->settings_content_section()` / `$this->settings_appearance_section()` reuses the already-registered callbacks instead of duplicating their copy. `$this` is in scope because `settings_page()` does `include_once` *within the method*. A 3-line comment documents the why so it doesn't read as accidental.
- **#74 does not weaken CSRF protection.** The form still emits WordPress's own nonce via `settings_fields()`, and `options.php` verifies it on submit. The removed field lived in the *default* section (which the tabbed view never renders) and was never checked anywhere — dead in two ways.
- **Scope:** left the `field_radio()` args `label` unused rather than wiring it into the markup — rendering it would change admin UI and isn't what #76 asks for; the issue is purely the shadowed variable.

## Test plan

- [x] `php -l` clean on `src/Admin/Settings.php` and `resources/views/admin/settings-page.php`
- [x] Grep confirms `field_textarea` and `fivetwofive_cta_nonce` / `settings_nonce` are fully removed; section callbacks are now referenced in the view
- [ ] Runtime smoke in LocalWP (open the CTA settings page; confirm both section descriptions render and Save still works) — **not run this round, per standing note; verified statically only**

## Follow-ups

- Remaining epic [#69](https://github.com/jaballer/fivetwofive-cw/issues/69) groups still open: C (#77–#78 admin JS), D (#79 preload), F (#82–#83 i18n + uninstall)