### PR TITLE
fix(cta): admin preview CSS/guard + drop site-wide preload (#77-#79)

### DIFF
--- a/wp-content/plugins/fivetwofive-cta/resources/assets/admin/scripts/fivetwofive-cta-admin.js
+++ b/wp-content/plugins/fivetwofive-cta/resources/assets/admin/scripts/fivetwofive-cta-admin.js
@@ -13,7 +13,7 @@
         const mediaUploadSections = $('.js-ftf-media-uploader-section');
         let mediaUploader;
 
-        if ( ! mediaUploadSections.length >= 1) {
+        if ( ! mediaUploadSections.length ) {
             return;
         }
 
@@ -46,7 +46,7 @@
                     const attachment = mediaUploader.state().get('selection').first().toJSON();
 
                     // Send the attachment URL to our custom image input field.
-                    imgContainer.html( '' ).append( '<img src="'+attachment.url+'" alt="" style="width=100%;max-width:300px;"/>' );
+                    imgContainer.html( '' ).append( '<img src="'+attachment.url+'" alt="" style="width:100%;max-width:300px;"/>' );
 
                     imgIdInput.val( attachment.id );
                 });

--- a/wp-content/plugins/fivetwofive-cta/src/Frontend/Shortcode.php
+++ b/wp-content/plugins/fivetwofive-cta/src/Frontend/Shortcode.php
@@ -66,14 +66,6 @@ class Shortcode {
 			array(),
 			$this->version
 		);
-		
-		// Add preload for performance
-		add_action('wp_head', function() {
-			printf(
-				'<link rel="preload" href="%s" as="style">',
-				esc_url(plugins_url('resources/assets/frontend/styles/fivetwofive-cta.css', FTF_CTA_PLUGIN_FILE))
-			);
-		});
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- **#77** — the admin media preview used invalid `width=100%`; corrected to `width:100%` so the preview is sized as intended. (Closes #77)
- **#78** — simplified the media-uploader guard from `! mediaUploadSections.length >= 1` to `! mediaUploadSections.length` — same behavior, no operator-precedence ambiguity. (Closes #78)
- **#79** — removed the unconditional `wp_head` `<link rel="preload">` that was injected on every front-end page. (Closes #79)

## Decisions baked in

- **#79 drops the preload rather than making it conditional.** The shortcode renders during `the_content`, *after* `wp_head` has already flushed, so a correct per-page preload would need to scan content in an earlier hook — more surface than this P2 warrants. The stylesheet is still registered on `wp_enqueue_scripts` and still enqueued when the shortcode actually renders (`Shortcode.php:107`, untouched), so there's **no functional regression** — only the site-wide "preloaded but not used" warnings and wasted bytes go away. The issue lists "drop entirely" as an acceptable fix and its acceptance criterion (no preload on non-shortcode pages) is fully met.
- **#78 is behavior-preserving.** The original `(!length) >= 1` happened to work by coincidence; the new form is the explicit guard that was intended. Left the separate, correct `colorPickerFields.length >= 1` guard alone.
- **Admin JS is served directly** (no build/minification for this plugin), so the source edit is the entire change — no `dist` to rebuild.

## Test plan

- [x] `php -l` clean on `src/Frontend/Shortcode.php`
- [x] `node --check` parses `resources/assets/admin/scripts/fivetwofive-cta-admin.js` clean
- [x] Grep confirms `width=100%`, the `! …>= 1` guard, and the preload block are all gone
- [ ] Runtime smoke in LocalWP (admin: set a CTA background image, confirm preview is constrained; front end: load a non-CTA page, confirm no preload `<link>` and no console warning) — **not run this round, per standing note; verified statically only**

## Follow-ups

- Remaining epic [#69](https://github.com/jaballer/fivetwofive-cw/issues/69): Group **F** (#82 i18n loader, #83 uninstall cleanup, #84 readme — deferred) and the #68 in-admin help-text enhancement