### PR TITLE
fix(theme): allow form elements in extended kses ruleset (#103)

### DIFF
--- a/wp-content/themes/fivetwofive-theme/inc/public/template-functions.php
+++ b/wp-content/themes/fivetwofive-theme/inc/public/template-functions.php
@@ -96,6 +96,37 @@ function fivetwofive_kses_extended_ruleset() {
 			'd'    => true,
 			'fill' => true,
 		),
+		// Allow <form> and <input> so shortcode-rendered forms (e.g. the
+		// contact form) survive kses in module content. ACF WYSIWYG fields
+		// expand shortcodes before this filter runs, so the form markup is
+		// already present when wp_kses() sees it. This ruleset already permits
+		// script/iframe/style, so it is a trusted-author ruleset and allowing
+		// form controls is consistent. (<label>, <textarea>, <button> are
+		// already permitted by the core "post" set.)
+		'form'     => array(
+			'class'      => true,
+			'id'         => true,
+			'method'     => true,
+			'action'     => true,
+			'enctype'    => true,
+			'novalidate' => true,
+		),
+		'input'    => array(
+			'class'         => true,
+			'id'            => true,
+			'name'          => true,
+			'type'          => true,
+			'value'         => true,
+			'placeholder'   => true,
+			'required'      => true,
+			'checked'       => true,
+			'readonly'      => true,
+			'disabled'      => true,
+			'tabindex'      => true,
+			'autocomplete'  => true,
+			'aria-hidden'   => true,
+			'aria-required' => true,
+		),
 	);
 
 	return array_merge( $kses_defaults, $args );

--- a/wp-content/themes/fivetwofive-theme/template-parts/modules/module-multi-column.php
+++ b/wp-content/themes/fivetwofive-theme/template-parts/modules/module-multi-column.php
@@ -231,7 +231,7 @@ if ( $module_animation_desktop || $module_animation_mobile ) {
 
 						<?php if ( $column_text ) : ?>
 							<div class="column-text mb-3 mb-md-4"
-								 style="<?php echo esc_attr( $text_color_inline_style ); ?>"><?php echo wp_kses( do_shortcode( $column_text ), fivetwofive_kses_extended_ruleset() ); ?></div>
+								 style="<?php echo esc_attr( $text_color_inline_style ); ?>"><?php echo do_shortcode( wp_kses( $column_text, fivetwofive_kses_extended_ruleset() ) ); ?></div>
 						<?php endif; ?>
 
 						<?php

--- a/wp-content/themes/fivetwofive-theme/template-parts/modules/module-multi-column.php
+++ b/wp-content/themes/fivetwofive-theme/template-parts/modules/module-multi-column.php
@@ -231,7 +231,7 @@ if ( $module_animation_desktop || $module_animation_mobile ) {
 
 						<?php if ( $column_text ) : ?>
 							<div class="column-text mb-3 mb-md-4"
-								 style="<?php echo esc_attr( $text_color_inline_style ); ?>"><?php echo do_shortcode( wp_kses( $column_text, fivetwofive_kses_extended_ruleset() ) ); ?></div>
+								 style="<?php echo esc_attr( $text_color_inline_style ); ?>"><?php echo wp_kses( do_shortcode( $column_text ), fivetwofive_kses_extended_ruleset() ); ?></div>
 						<?php endif; ?>
 
 						<?php


### PR DESCRIPTION
## Summary

- Form-emitting shortcodes (notably `[fivetwofive_contact_form]`) now render in full inside ACF module content — multi-column and any module using the extended kses ruleset (parent **and** child) — instead of being stripped to a dead textarea + button.
- Root cause: ACF **WYSIWYG** fields expand shortcodes (via `the_content`) *before* the module outputs them, so the form reached `wp_kses()` as already-expanded `<form>`/`<input>` markup. `fivetwofive_kses_extended_ruleset()` omitted form elements, so kses stripped the `<form>` wrapper and every `<input>`.
- Fix: add `<form>` and `<input>` to `fivetwofive_kses_extended_ruleset()`.

Closes #103

**How to review:** the effective change is a **single function** in `inc/public/template-functions.php` (see *Files changed*). The branch has two commits — `aaca4c1` was a first attempt (reordering `wp_kses`/`do_shortcode` in the multi-column module) that does **not** work because the field is pre-expanded; `ae1bad3` reverts that and applies the real fix. Net diff is only the ruleset addition.

## Decisions baked in

- **Fix the allowlist, not the module's `wp_kses`/`do_shortcode` order.** The field is ACF WYSIWYG, so the shortcode is already expanded before the module runs — order is irrelevant, only the allowlist matters. Verified live: both orders yield **0** inputs under the old ruleset.
- **Extend the *shared* ruleset, consistent with its existing posture.** It already permits `<script src>`, `<iframe>`, and `<style>` — an explicitly trusted-author allowlist — so `<form>`/`<input>` add no new risk class. This also fixes form shortcodes in every module that uses the ruleset, including the child theme (e.g. `module-content-and-media.php`), not just multi-column (the form's likely primary placement).
- **Only `<form>` and `<input>` added; no event handlers.** `<label>`, `<textarea>`, `<button>` are already permitted by the core `post` set — which is why they rendered while the inputs vanished. The added attribute lists carry no `on*` handlers (kses strips those regardless).
- **`fivetwofive_kses_extended_ruleset()` is parent-only and not pluggable** (no `function_exists` guard, no child redefinition), so the parent edit is authoritative.

## Test plan

- [x] No asset rebuild — PHP only, no SCSS/JS source touched.
- [x] Ran the module's exact expression on the live demo page's real field value (post 1681): `<form>` present, **9** inputs, textarea intact — vs **0** inputs under the old ruleset.
- [x] Flushed object cache (object-cache-pro); Breeze page-cache dir was already empty. Re-fetched the served page (`/modules-demo-page/`, cache-busting query): HTML now contains `class="ftf-contact-form"`, the plugin stylesheet, and **11** `<input>` total (the contact form contributes 9).
- [x] Confirmed `fivetwofive_kses_extended_ruleset()` has no child-theme override — the parent definition is the one in use.
- [ ] Final in-browser visual pass on `/modules-demo-page/` — recommended; markup + stylesheet confirmed present in the served HTML, not yet eyeballed in a browser.

## Follow-ups

- Related trackers reference this as the theme-side fix: contact-form feature #57 and plugin-hardening epic #102.