### PR TITLE
chore: add grouped Dependabot config for theme npm toolchains

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,9 @@
 # Dependabot configuration.
 #
-# The two theme build toolchains (gulp / babel / eslint / browser-sync) are the
-# only npm dependency trees in the repo, and their advisories are all
-# development-scope: node_modules is git-ignored and the live site serves the
-# compiled assets/dist, so none of it ships. Grouping collapses scattered
-# alerts into a few reviewable PRs. There is no CI here — verify the theme
-# build before merging any bump.
+# The two theme package manifests are the only first-party npm dependency trees
+# in the repo. Grouping keeps scheduled dev-toolchain bumps and security-alert
+# updates reviewable. There is no CI here; verify the theme build before
+# merging any bump.
 version: 2
 updates:
   - package-ecosystem: "npm"
@@ -18,6 +16,10 @@ updates:
         dependency-type: "development"
         patterns:
           - "*"
+      security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
 
   - package-ecosystem: "npm"
     directory: "/wp-content/themes/fivetwofive-theme-child"
@@ -27,5 +29,9 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: "development"
+        patterns:
+          - "*"
+      security-updates:
+        applies-to: "security-updates"
         patterns:
           - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# Dependabot configuration.
+#
+# The two theme build toolchains (gulp / babel / eslint / browser-sync) are the
+# only npm dependency trees in the repo, and their advisories are all
+# development-scope: node_modules is git-ignored and the live site serves the
+# compiled assets/dist, so none of it ships. Grouping collapses scattered
+# alerts into a few reviewable PRs. There is no CI here — verify the theme
+# build before merging any bump.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/wp-content/themes/fivetwofive-theme"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/wp-content/themes/fivetwofive-theme-child"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
           - "*"
       security-updates:
         applies-to: "security-updates"
+        dependency-type: "development"
         patterns:
           - "*"
 
@@ -33,5 +34,6 @@ updates:
           - "*"
       security-updates:
         applies-to: "security-updates"
+        dependency-type: "development"
         patterns:
           - "*"

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@
 
 !.cursor/
 
+!.github/
+
 # Claude Code skills — track the skills only; keep local settings/worktrees out
 !.claude/
 .claude/*


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` enabling weekly npm version updates for the parent and child theme build toolchains.
- Groups each theme's **development** dependencies into a single batched PR, so the 51 scattered alerts become a few reviewable PRs.
- Whitelists `.github/` in the deny-all `.gitignore` so the config (and future templates) are tracked.

## Decisions baked in

- **Grouped by `dependency-type: development`** because every current advisory is dev-scope build tooling (gulp / babel / eslint / browser-sync). `node_modules` is git-ignored and the live site serves compiled `assets/dist`, so none of it ships — this is hygiene, not production risk.
- **Weekly cadence, `open-pull-requests-limit: 5`** to keep update noise bounded.
- **Production deps left ungrouped** (the only one is `bootstrap`, parent theme), so a runtime bump gets its own PR and a deliberate rebuild/review.
- **Config only — bumps nothing.** Dependabot opens the grouped PRs; with no CI, each must be build-verified before merge.

## Test plan

- [x] `ruby -ryaml` parse — valid YAML, `version: 2`, 2 update entries each with the `dev-dependencies` group
- [x] `git check-ignore .github/dependabot.yml` → empty (the `!.github/` whitelist works under the deny-all `.gitignore`)
- [x] `directory` paths match the two tracked theme `package.json` locations
- [x] Config only — no SCSS/JS/PHP touched, no asset rebuild, no runtime impact

## Follow-ups

- When the first grouped Dependabot PR lands, run `npm run build` in the affected theme and verify before merging (no CI).
- Optional next `.github/` additions: issue + PR templates.