### PR TITLE
docs(cta): correct plugin metadata

### DIFF
--- a/wp-content/plugins/fivetwofive-cta/fivetwofive-cta.php
+++ b/wp-content/plugins/fivetwofive-cta/fivetwofive-cta.php
@@ -10,7 +10,7 @@
  * @wordpress-plugin
  * Plugin Name:       Call To Action
  * Plugin URI:        https://fivetwofive.com/
- * Description:       Add customizable call-to-action blocks with advanced styling options and analytics tracking.
+ * Description:       Add customizable call-to-action blocks with reusable shortcode output and style controls.
  * Version:           1.0.3
  * Requires at least: 5.2
  * Requires PHP:      7.4
@@ -25,8 +25,8 @@
  * on your WordPress site. Features include:
  * - Customizable styles and layouts
  * - Responsive design
- * - Analytics tracking
- * - A/B testing capabilities
+ * - Shortcode rendering
+ * - Global settings with per-shortcode overrides
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -51,7 +51,7 @@ if ( ! class_exists( 'FiveTwoFive_CTA', false ) ) {
 /**
  * Returns the main instance of FiveTwoFive_CTA.
  *
- * @since  2.1
+ * @since  1.0.0
  * @return FiveTwoFive_CTA
  */
 function FTF_CTA() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid

--- a/wp-content/plugins/fivetwofive-cta/includes/class-fivetwofive-cta.php
+++ b/wp-content/plugins/fivetwofive-cta/includes/class-fivetwofive-cta.php
@@ -54,7 +54,7 @@ class FiveTwoFive_CTA {
 	 * The single instance of the class.
 	 *
 	 * @var FiveTwoFive_CTA
-	 * @since 2.1
+	 * @since 1.0.0
 	 */
 	private static ?self $_instance = null;
 
@@ -63,7 +63,7 @@ class FiveTwoFive_CTA {
 	 *
 	 * Ensures only one instance of FiveTwoFive_CTA is loaded or can be loaded.
 	 *
-	 * @since 2.1
+	 * @since 1.0.0
 	 * @static
 	 * @see FiveTwoFive_CTA()
 	 * @return FiveTwoFive_CTA - Main instance.


### PR DESCRIPTION
## Summary
- Remove stale analytics tracking and A/B testing claims from the CTA plugin header/docblock.
- Correct boilerplate `@since 2.1` tags to match the v1.x CTA plugin history.

## Decisions baked in
- Kept this PR scoped to the CTA metadata/docblock cleanup from #80 and #81.
- Did not include adjacent CTA cleanup items from #82/#83.
- No runtime behavior changes intended.

## Test plan
- `rg -n "analytics|A/B|split test|tracking|@since 2\.1" wp-content/plugins/fivetwofive-cta || true`
- `php -l wp-content/plugins/fivetwofive-cta/fivetwofive-cta.php`
- `php -l wp-content/plugins/fivetwofive-cta/includes/class-fivetwofive-cta.php`
- No theme build needed; PHP comments/plugin metadata only.

## Follow-ups
- Continue the broader custom plugin metadata audit in #60.

Closes #80
Closes #81
Refs #60