### PR TITLE
feat(contact-form): add plugin settings page (#119)

### DIFF
--- a/wp-content/plugins/fivetwofive-contact-form/fivetwofive-contact-form.php
+++ b/wp-content/plugins/fivetwofive-contact-form/fivetwofive-contact-form.php
@@ -11,7 +11,7 @@
  * Plugin Name:       FiveTwoFive Contact Form
  * Plugin URI:        https://fivetwofive.com/
  * Description:       A lightweight, dependency-light contact form. Stores every submission as a record and sends notifications via wp_mail() with a swappable mail transport.
- * Version:           1.0.0
+ * Version:           1.1.0
  * Requires at least: 5.2
  * Requires PHP:      7.4
  * Author:            FiveTwoFive Creative Team
@@ -27,7 +27,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Current plugin version.
  */
-define( 'FTF_CONTACT_FORM_VERSION', '1.0.0' );
+define( 'FTF_CONTACT_FORM_VERSION', '1.1.0' );
 
 if ( ! defined( 'FTF_CONTACT_FORM_PLUGIN_FILE' ) ) {
 	define( 'FTF_CONTACT_FORM_PLUGIN_FILE', __FILE__ );

--- a/wp-content/plugins/fivetwofive-contact-form/includes/class-fivetwofive-contact-form.php
+++ b/wp-content/plugins/fivetwofive-contact-form/includes/class-fivetwofive-contact-form.php
@@ -12,6 +12,7 @@
  * @subpackage FiveTwoFive_Contact_Form/includes
  */
 
+use FiveTwoFive\FiveTwoFive_Contact_Form\Admin\Settings;
 use FiveTwoFive\FiveTwoFive_Contact_Form\Form\Endpoints;
 use FiveTwoFive\FiveTwoFive_Contact_Form\Form\Handler;
 use FiveTwoFive\FiveTwoFive_Contact_Form\Frontend\Shortcode;
@@ -130,7 +131,11 @@ class FiveTwoFive_Contact_Form {
 		add_action( 'add_meta_boxes', array( $this->submission, 'add_meta_box' ) );
 		add_action( 'edit_form_top', array( $this->submission, 'mark_read' ) );
 
-		// Settings page is wired in here in a subsequent commit.
+		// Settings page: a submenu under the Contact Form menu, backed by the
+		// Settings API. The Mailer reads these values at send time.
+		$settings = new Settings( $this->plugin_name, $this->version );
+		add_action( 'admin_menu', array( $settings, 'add_menu' ) );
+		add_action( 'admin_init', array( $settings, 'register_settings' ) );
 	}
 
 	/**

--- a/wp-content/plugins/fivetwofive-contact-form/includes/class-fivetwofive-contact-form.php
+++ b/wp-content/plugins/fivetwofive-contact-form/includes/class-fivetwofive-contact-form.php
@@ -67,6 +67,14 @@ class FiveTwoFive_Contact_Form {
 	private Submission $submission;
 
 	/**
+	 * The settings page controller.
+	 *
+	 * @since 1.1.0
+	 * @var   Settings
+	 */
+	private Settings $settings;
+
+	/**
 	 * Main FiveTwoFive_Contact_Form instance.
 	 *
 	 * Ensures only one instance of the plugin is loaded or can be loaded.
@@ -94,6 +102,7 @@ class FiveTwoFive_Contact_Form {
 		$this->plugin_name = 'fivetwofive_contact_form';
 
 		$this->submission = new Submission( $this->plugin_name, $this->version );
+		$this->settings   = new Settings( $this->plugin_name, $this->version );
 
 		$this->define_public_hooks();
 		$this->define_admin_hooks();
@@ -108,6 +117,10 @@ class FiveTwoFive_Contact_Form {
 		// The submissions post type must exist on every request (the front-end
 		// submit handler writes to it), so it registers on the shared init hook.
 		add_action( 'init', array( $this->submission, 'register' ) );
+
+		// The setting + its REST schema must register for REST requests too
+		// (admin_init never fires for /wp-json), so register it on init.
+		add_action( 'init', array( $this->settings, 'register_option' ) );
 
 		$shortcode = new Shortcode( $this->plugin_name, $this->version );
 		add_action( 'wp_enqueue_scripts', array( $shortcode, 'enqueue_assets' ) );
@@ -131,11 +144,11 @@ class FiveTwoFive_Contact_Form {
 		add_action( 'add_meta_boxes', array( $this->submission, 'add_meta_box' ) );
 		add_action( 'edit_form_top', array( $this->submission, 'mark_read' ) );
 
-		// Settings page: a submenu under the Contact Form menu, backed by the
-		// Settings API. The Mailer reads these values at send time.
-		$settings = new Settings( $this->plugin_name, $this->version );
-		add_action( 'admin_menu', array( $settings, 'add_menu' ) );
-		add_action( 'admin_init', array( $settings, 'register_settings' ) );
+		// Settings page admin UI: the submenu plus the section/field rendering.
+		// The setting itself (and its REST schema) registers on init — see
+		// define_public_hooks() — so it also applies to REST requests.
+		add_action( 'admin_menu', array( $this->settings, 'add_menu' ) );
+		add_action( 'admin_init', array( $this->settings, 'register_fields' ) );
 	}
 
 	/**

--- a/wp-content/plugins/fivetwofive-contact-form/resources/views/admin/settings-page.php
+++ b/wp-content/plugins/fivetwofive-contact-form/resources/views/admin/settings-page.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * The Contact Form settings page.
+ *
+ * Included from FiveTwoFive\FiveTwoFive_Contact_Form\Admin\Settings::render_page(),
+ * so $this is the Settings instance.
+ *
+ * @package FiveTwoFive_Contact_Form
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+// Re-check capability at the point of render.
+if ( ! current_user_can( 'manage_options' ) ) {
+	return;
+}
+
+// WordPress appends ?settings-updated=true on a successful save. The value is
+// not used (only its presence), so the isset() check needs no nonce/sanitize.
+if ( isset( $_GET['settings-updated'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	add_settings_error( $this::NOTICES, 'ftf_contact_form_saved', __( 'Settings saved.', 'fivetwofive-contact-form' ), 'updated' );
+}
+
+// Renders both the "saved" notice and any validation errors added in sanitize().
+settings_errors( $this::NOTICES );
+?>
+<div class="wrap">
+	<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+
+	<form action="options.php" method="post">
+		<?php
+		settings_fields( $this::GROUP );
+		do_settings_sections( $this::PAGE_SLUG );
+		submit_button();
+		?>
+	</form>
+</div>

--- a/wp-content/plugins/fivetwofive-contact-form/src/Admin/Settings.php
+++ b/wp-content/plugins/fivetwofive-contact-form/src/Admin/Settings.php
@@ -159,15 +159,16 @@ class Settings {
 	}
 
 	/**
-	 * Register the setting, section, and fields. Hooked to admin_init.
+	 * Register the setting and its typed REST schema.
+	 *
+	 * Hooked to `init` (not `admin_init`) so it also runs for REST requests: the
+	 * core settings controller reads registered settings when building
+	 * /wp/v2/settings, and `admin_init` never fires for REST. Running on every
+	 * request is cheap and idempotent; the sanitize_callback still gates writes.
 	 *
 	 * @since 1.1.0
 	 */
-	public function register_settings(): void {
-		// Registered with a typed REST schema so the settings are exposed on the
-		// core /wp/v2/settings endpoint (manage_options only), self-validating,
-		// and block-editor friendly. The sanitize_callback still runs on every
-		// save as the server-side gate.
+	public function register_option(): void {
 		register_setting(
 			self::GROUP,
 			self::OPTION,
@@ -193,7 +194,15 @@ class Settings {
 				),
 			)
 		);
+	}
 
+	/**
+	 * Register the settings-page section and fields. Admin-only page UI, so
+	 * hooked to `admin_init`.
+	 *
+	 * @since 1.1.0
+	 */
+	public function register_fields(): void {
 		add_settings_section(
 			self::SECTION,
 			__( 'Notifications', 'fivetwofive-contact-form' ),

--- a/wp-content/plugins/fivetwofive-contact-form/src/Admin/Settings.php
+++ b/wp-content/plugins/fivetwofive-contact-form/src/Admin/Settings.php
@@ -1,0 +1,365 @@
+<?php
+/**
+ * The plugin settings page: notification recipient, sender identity, subject
+ * prefix, and notification format. Registered as a submenu under the Contact
+ * Form (ftf_submission) admin menu and backed by the WordPress Settings API.
+ *
+ * The stored option name (`fivetwofive_contact_form_options`) matches the key
+ * removed by uninstall.php, so deleting the plugin cleans these settings up.
+ *
+ * @package    FiveTwoFive_Contact_Form
+ * @subpackage FiveTwoFive_Contact_Form/Admin
+ * @since      1.1.0
+ */
+
+namespace FiveTwoFive\FiveTwoFive_Contact_Form\Admin;
+
+use FiveTwoFive\FiveTwoFive_Contact_Form\PostType\Submission;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers and renders the contact form settings page.
+ *
+ * @since 1.1.0
+ */
+class Settings {
+
+	/**
+	 * Option name holding the settings array. Matches uninstall.php.
+	 *
+	 * @var string
+	 */
+	public const OPTION = 'fivetwofive_contact_form_options';
+
+	/**
+	 * Settings API group (passed to register_setting / settings_fields).
+	 *
+	 * @var string
+	 */
+	public const GROUP = 'fivetwofive_contact_form';
+
+	/**
+	 * Settings page slug (the add_submenu_page menu slug + Settings API page).
+	 *
+	 * @var string
+	 */
+	public const PAGE_SLUG = 'fivetwofive-contact-form-settings';
+
+	/**
+	 * Settings section id.
+	 *
+	 * @var string
+	 */
+	private const SECTION = 'ftf_contact_form_notification';
+
+	/**
+	 * Admin notice group for settings errors. Public so the page view can pass
+	 * it to settings_errors().
+	 *
+	 * @var string
+	 */
+	public const NOTICES = 'fivetwofive_contact_form_messages';
+
+	/**
+	 * The slug of this plugin.
+	 *
+	 * @var string
+	 */
+	private string $plugin_name;
+
+	/**
+	 * The version of this plugin.
+	 *
+	 * @var string
+	 */
+	private string $version;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $plugin_name The plugin slug.
+	 * @param string $version     The plugin version.
+	 */
+	public function __construct( string $plugin_name, string $version ) {
+		$this->plugin_name = $plugin_name;
+		$this->version     = $version;
+	}
+
+	/**
+	 * Default settings. Empty string means "fall back" (see get()): the
+	 * recipient falls back to the site admin email, the From identity falls
+	 * back to the transport's default.
+	 *
+	 * @since  1.1.0
+	 * @return array
+	 */
+	public static function defaults(): array {
+		return array(
+			'recipient'      => '',
+			'from_name'      => '',
+			'from_email'     => '',
+			'subject_prefix' => '[Contact]',
+			'html_email'     => '0',
+		);
+	}
+
+	/**
+	 * Read a single setting, falling back to its default when unset/empty.
+	 *
+	 * Static so the Mailer (and any other consumer) can read settings without
+	 * holding a Settings instance.
+	 *
+	 * @since  1.1.0
+	 * @param  string $key      Setting key.
+	 * @param  string $fallback Value to return when neither a stored value nor
+	 *                          a non-empty default exists.
+	 * @return string
+	 */
+	public static function get( string $key, string $fallback = '' ): string {
+		$options = get_option( self::OPTION, array() );
+
+		if ( is_array( $options ) && isset( $options[ $key ] ) && '' !== $options[ $key ] ) {
+			return (string) $options[ $key ];
+		}
+
+		$defaults = self::defaults();
+
+		if ( array_key_exists( $key, $defaults ) && '' !== $defaults[ $key ] ) {
+			return (string) $defaults[ $key ];
+		}
+
+		return $fallback;
+	}
+
+	/**
+	 * Add the Settings submenu under the Contact Form menu. Hooked to admin_menu.
+	 *
+	 * @since 1.1.0
+	 */
+	public function add_menu(): void {
+		add_submenu_page(
+			'edit.php?post_type=' . Submission::POST_TYPE,
+			__( 'Contact Form Settings', 'fivetwofive-contact-form' ),
+			__( 'Settings', 'fivetwofive-contact-form' ),
+			'manage_options',
+			self::PAGE_SLUG,
+			array( $this, 'render_page' )
+		);
+	}
+
+	/**
+	 * Render the settings page wrapper. Capability is re-checked in the view.
+	 *
+	 * @since 1.1.0
+	 */
+	public function render_page(): void {
+		include dirname( FTF_CONTACT_FORM_PLUGIN_FILE ) . '/resources/views/admin/settings-page.php';
+	}
+
+	/**
+	 * Register the setting, section, and fields. Hooked to admin_init.
+	 *
+	 * @since 1.1.0
+	 */
+	public function register_settings(): void {
+		// Registered with a typed REST schema so the settings are exposed on the
+		// core /wp/v2/settings endpoint (manage_options only), self-validating,
+		// and block-editor friendly. The sanitize_callback still runs on every
+		// save as the server-side gate.
+		register_setting(
+			self::GROUP,
+			self::OPTION,
+			array(
+				'type'              => 'object',
+				'sanitize_callback' => array( $this, 'sanitize' ),
+				'default'           => self::defaults(),
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'                 => 'object',
+						'properties'           => array(
+							'recipient'      => array( 'type' => 'string' ),
+							'from_name'      => array( 'type' => 'string' ),
+							'from_email'     => array( 'type' => 'string' ),
+							'subject_prefix' => array( 'type' => 'string' ),
+							'html_email'     => array(
+								'type' => 'string',
+								'enum' => array( '0', '1' ),
+							),
+						),
+						'additionalProperties' => false,
+					),
+				),
+			)
+		);
+
+		add_settings_section(
+			self::SECTION,
+			__( 'Notifications', 'fivetwofive-contact-form' ),
+			array( $this, 'section_notification' ),
+			self::PAGE_SLUG
+		);
+
+		add_settings_field(
+			'recipient',
+			__( 'Notification recipient', 'fivetwofive-contact-form' ),
+			array( $this, 'field_input' ),
+			self::PAGE_SLUG,
+			self::SECTION,
+			array(
+				'id'          => 'recipient',
+				'type'        => 'email',
+				'placeholder' => (string) get_option( 'admin_email' ),
+				'description' => __( 'Where submission notifications are sent. Leave blank to use the site admin email.', 'fivetwofive-contact-form' ),
+			)
+		);
+
+		add_settings_field(
+			'from_name',
+			__( 'Sender name', 'fivetwofive-contact-form' ),
+			array( $this, 'field_input' ),
+			self::PAGE_SLUG,
+			self::SECTION,
+			array(
+				'id'          => 'from_name',
+				'type'        => 'text',
+				'description' => __( 'Optional "From" name on the notification.', 'fivetwofive-contact-form' ),
+			)
+		);
+
+		add_settings_field(
+			'from_email',
+			__( 'Sender email (From)', 'fivetwofive-contact-form' ),
+			array( $this, 'field_input' ),
+			self::PAGE_SLUG,
+			self::SECTION,
+			array(
+				'id'          => 'from_email',
+				'type'        => 'email',
+				'description' => __( 'Optional "From" address. Leave blank to let the mail transport set it. A transport like Postmark with "force from" enabled may override this.', 'fivetwofive-contact-form' ),
+			)
+		);
+
+		add_settings_field(
+			'subject_prefix',
+			__( 'Subject prefix', 'fivetwofive-contact-form' ),
+			array( $this, 'field_input' ),
+			self::PAGE_SLUG,
+			self::SECTION,
+			array(
+				'id'          => 'subject_prefix',
+				'type'        => 'text',
+				'placeholder' => '[Contact]',
+				'description' => __( 'Prepended to the notification subject line.', 'fivetwofive-contact-form' ),
+			)
+		);
+
+		add_settings_field(
+			'html_email',
+			__( 'Send as HTML', 'fivetwofive-contact-form' ),
+			array( $this, 'field_checkbox' ),
+			self::PAGE_SLUG,
+			self::SECTION,
+			array(
+				'id'          => 'html_email',
+				'label'       => __( 'Send the notification as HTML', 'fivetwofive-contact-form' ),
+				'description' => __( 'Recommended when a transport forces HTML or open-tracking (e.g. Postmark) — otherwise the plain-text line breaks collapse into a single run-on line.', 'fivetwofive-contact-form' ),
+			)
+		);
+	}
+
+	/**
+	 * Section description.
+	 *
+	 * @since 1.1.0
+	 */
+	public function section_notification(): void {
+		echo '<p>' . esc_html__( 'Control where contact submissions are sent and how the notification email is addressed and formatted.', 'fivetwofive-contact-form' ) . '</p>';
+	}
+
+	/**
+	 * Sanitize the submitted settings. Returns only known keys so the stored
+	 * option never accumulates stray data.
+	 *
+	 * @since  1.1.0
+	 * @param  mixed $input Raw submitted value.
+	 * @return array
+	 */
+	public function sanitize( $input ): array {
+		$input = is_array( $input ) ? $input : array();
+		$clean = array();
+
+		$clean['recipient']      = isset( $input['recipient'] ) ? sanitize_email( (string) $input['recipient'] ) : '';
+		$clean['from_name']      = isset( $input['from_name'] ) ? sanitize_text_field( (string) $input['from_name'] ) : '';
+		$clean['from_email']     = isset( $input['from_email'] ) ? sanitize_email( (string) $input['from_email'] ) : '';
+		$clean['subject_prefix'] = isset( $input['subject_prefix'] ) ? sanitize_text_field( (string) $input['subject_prefix'] ) : '';
+		$clean['html_email']     = empty( $input['html_email'] ) ? '0' : '1';
+
+		// Surface (and drop) an invalid email rather than storing it silently.
+		if ( '' !== $clean['recipient'] && ! is_email( $clean['recipient'] ) ) {
+			add_settings_error( self::NOTICES, 'recipient', __( 'The notification recipient must be a valid email address.', 'fivetwofive-contact-form' ) );
+			$clean['recipient'] = '';
+		}
+
+		if ( '' !== $clean['from_email'] && ! is_email( $clean['from_email'] ) ) {
+			add_settings_error( self::NOTICES, 'from_email', __( 'The sender email must be a valid email address.', 'fivetwofive-contact-form' ) );
+			$clean['from_email'] = '';
+		}
+
+		return $clean;
+	}
+
+	/**
+	 * Render a text/email input field.
+	 *
+	 * @since 1.1.0
+	 * @param array $args { id, type, placeholder, description }.
+	 */
+	public function field_input( array $args ): void {
+		$options = get_option( self::OPTION, self::defaults() );
+
+		$id    = isset( $args['id'] ) ? (string) $args['id'] : '';
+		$type  = isset( $args['type'] ) ? (string) $args['type'] : 'text';
+		$value = isset( $options[ $id ] ) ? (string) $options[ $id ] : '';
+
+		printf(
+			'<input type="%1$s" id="%2$s" name="%3$s[%4$s]" value="%5$s" class="regular-text" placeholder="%6$s" />',
+			esc_attr( $type ),
+			esc_attr( self::OPTION . '_' . $id ),
+			esc_attr( self::OPTION ),
+			esc_attr( $id ),
+			esc_attr( $value ),
+			esc_attr( isset( $args['placeholder'] ) ? (string) $args['placeholder'] : '' )
+		);
+
+		if ( ! empty( $args['description'] ) ) {
+			printf( '<p class="description">%s</p>', esc_html( (string) $args['description'] ) );
+		}
+	}
+
+	/**
+	 * Render a single checkbox field (stored as '1' / '0').
+	 *
+	 * @since 1.1.0
+	 * @param array $args { id, label, description }.
+	 */
+	public function field_checkbox( array $args ): void {
+		$options = get_option( self::OPTION, self::defaults() );
+
+		$id      = isset( $args['id'] ) ? (string) $args['id'] : '';
+		$checked = isset( $options[ $id ] ) && '1' === (string) $options[ $id ];
+
+		printf(
+			'<label><input type="checkbox" id="%1$s" name="%2$s[%3$s]" value="1" %4$s /> %5$s</label>',
+			esc_attr( self::OPTION . '_' . $id ),
+			esc_attr( self::OPTION ),
+			esc_attr( $id ),
+			checked( $checked, true, false ),
+			esc_html( isset( $args['label'] ) ? (string) $args['label'] : '' )
+		);
+
+		if ( ! empty( $args['description'] ) ) {
+			printf( '<p class="description">%s</p>', esc_html( (string) $args['description'] ) );
+		}
+	}
+}

--- a/wp-content/plugins/fivetwofive-contact-form/src/Admin/Settings.php
+++ b/wp-content/plugins/fivetwofive-contact-form/src/Admin/Settings.php
@@ -14,6 +14,7 @@
 
 namespace FiveTwoFive\FiveTwoFive_Contact_Form\Admin;
 
+use FiveTwoFive\FiveTwoFive_Contact_Form\Frontend\Shortcode;
 use FiveTwoFive\FiveTwoFive_Contact_Form\PostType\Submission;
 
 defined( 'ABSPATH' ) || exit;
@@ -274,7 +275,14 @@ class Settings {
 	 * @since 1.1.0
 	 */
 	public function section_notification(): void {
-		echo '<p>' . esc_html__( 'Control where contact submissions are sent and how the notification email is addressed and formatted.', 'fivetwofive-contact-form' ) . '</p>';
+		printf(
+			'<p>%s</p>',
+			sprintf(
+				/* translators: %s: the contact form shortcode, wrapped in a <code> tag. */
+				esc_html__( 'Use the shortcode %s to display the contact form on a page or post. The settings below control where submissions are sent and how the notification email is addressed and formatted.', 'fivetwofive-contact-form' ),
+				'<code>[' . esc_html( Shortcode::SHORTCODE ) . ']</code>'
+			)
+		);
 	}
 
 	/**

--- a/wp-content/plugins/fivetwofive-contact-form/src/Admin/Settings.php
+++ b/wp-content/plugins/fivetwofive-contact-form/src/Admin/Settings.php
@@ -295,8 +295,12 @@ class Settings {
 	}
 
 	/**
-	 * Sanitize the submitted settings. Returns only known keys so the stored
-	 * option never accumulates stray data.
+	 * Sanitize the submitted settings.
+	 *
+	 * Overlays the submitted keys onto the currently-stored values so a partial
+	 * update — e.g. a REST PATCH of a single property via /wp/v2/settings —
+	 * preserves the other fields instead of blanking them. Only known keys are
+	 * kept, so the stored option never accumulates stray data.
 	 *
 	 * @since  1.1.0
 	 * @param  mixed $input Raw submitted value.
@@ -304,26 +308,63 @@ class Settings {
 	 */
 	public function sanitize( $input ): array {
 		$input = is_array( $input ) ? $input : array();
-		$clean = array();
 
-		$clean['recipient']      = isset( $input['recipient'] ) ? sanitize_email( (string) $input['recipient'] ) : '';
-		$clean['from_name']      = isset( $input['from_name'] ) ? sanitize_text_field( (string) $input['from_name'] ) : '';
-		$clean['from_email']     = isset( $input['from_email'] ) ? sanitize_email( (string) $input['from_email'] ) : '';
-		$clean['subject_prefix'] = isset( $input['subject_prefix'] ) ? sanitize_text_field( (string) $input['subject_prefix'] ) : '';
-		$clean['html_email']     = empty( $input['html_email'] ) ? '0' : '1';
+		// Start from the current stored values (or defaults). The admin form
+		// submits every field — the checkbox via a hidden companion input (see
+		// field_checkbox), so an explicit uncheck still records '0' — while a
+		// partial REST body only carries the keys it means to change.
+		$current = get_option( self::OPTION, self::defaults() );
+		$clean   = is_array( $current ) ? array_merge( self::defaults(), $current ) : self::defaults();
 
-		// Surface (and drop) an invalid email rather than storing it silently.
+		if ( isset( $input['recipient'] ) ) {
+			$clean['recipient'] = sanitize_email( (string) $input['recipient'] );
+		}
+
+		if ( isset( $input['from_name'] ) ) {
+			$clean['from_name'] = sanitize_text_field( (string) $input['from_name'] );
+		}
+
+		if ( isset( $input['from_email'] ) ) {
+			$clean['from_email'] = sanitize_email( (string) $input['from_email'] );
+		}
+
+		if ( isset( $input['subject_prefix'] ) ) {
+			$clean['subject_prefix'] = sanitize_text_field( (string) $input['subject_prefix'] );
+		}
+
+		if ( isset( $input['html_email'] ) ) {
+			$clean['html_email'] = empty( $input['html_email'] ) ? '0' : '1';
+		}
+
+		// Drop invalid emails rather than storing them.
 		if ( '' !== $clean['recipient'] && ! is_email( $clean['recipient'] ) ) {
-			add_settings_error( self::NOTICES, 'recipient', __( 'The notification recipient must be a valid email address.', 'fivetwofive-contact-form' ) );
+			$this->add_notice( 'recipient', __( 'The notification recipient must be a valid email address.', 'fivetwofive-contact-form' ) );
 			$clean['recipient'] = '';
 		}
 
 		if ( '' !== $clean['from_email'] && ! is_email( $clean['from_email'] ) ) {
-			add_settings_error( self::NOTICES, 'from_email', __( 'The sender email must be a valid email address.', 'fivetwofive-contact-form' ) );
+			$this->add_notice( 'from_email', __( 'The sender email must be a valid email address.', 'fivetwofive-contact-form' ) );
 			$clean['from_email'] = '';
 		}
 
 		return $clean;
+	}
+
+	/**
+	 * Add a Settings API error notice, but only when that API is loaded.
+	 *
+	 * Settings can be saved via REST (/wp/v2/settings), where add_settings_error()
+	 * — part of wp-admin/includes/template.php — is not available; calling it
+	 * there would fatal. On that path the value is still dropped, just silently.
+	 *
+	 * @since 1.1.0
+	 * @param string $code    Error slug.
+	 * @param string $message Human-readable message.
+	 */
+	private function add_notice( string $code, string $message ): void {
+		if ( function_exists( 'add_settings_error' ) ) {
+			add_settings_error( self::NOTICES, $code, $message );
+		}
 	}
 
 	/**
@@ -365,6 +406,16 @@ class Settings {
 
 		$id      = isset( $args['id'] ) ? (string) $args['id'] : '';
 		$checked = isset( $options[ $id ] ) && '1' === (string) $options[ $id ];
+
+		// Hidden companion: an unchecked box submits nothing, so this guarantees
+		// the key is present on every admin save ('0' unless the checkbox, which
+		// shares the name and follows it, overrides with '1'). That lets sanitize()
+		// treat a *missing* key as "preserve" for partial REST updates.
+		printf(
+			'<input type="hidden" name="%1$s[%2$s]" value="0" />',
+			esc_attr( self::OPTION ),
+			esc_attr( $id )
+		);
 
 		printf(
 			'<label><input type="checkbox" id="%1$s" name="%2$s[%3$s]" value="1" %4$s /> %5$s</label>',

--- a/wp-content/plugins/fivetwofive-contact-form/src/Mailer/Mailer.php
+++ b/wp-content/plugins/fivetwofive-contact-form/src/Mailer/Mailer.php
@@ -13,6 +13,8 @@
 
 namespace FiveTwoFive\FiveTwoFive_Contact_Form\Mailer;
 
+use FiveTwoFive\FiveTwoFive_Contact_Form\Admin\Settings;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -50,14 +52,18 @@ class Mailer {
 	/**
 	 * Resolve the notification recipient.
 	 *
-	 * Phase 1 uses the site admin email. Phase 2 wires this to the Company
-	 * Options ACF field. Filterable either way.
+	 * Uses the recipient from the settings page when set, otherwise falls back
+	 * to the site admin email. Filterable either way.
 	 *
 	 * @since  1.0.0
 	 * @return string Recipient email address.
 	 */
 	public function recipient(): string {
-		$recipient = (string) get_option( 'admin_email' );
+		$recipient = Settings::get( 'recipient' );
+
+		if ( '' === $recipient ) {
+			$recipient = (string) get_option( 'admin_email' );
+		}
 
 		/**
 		 * Filter the contact form notification recipient.
@@ -92,10 +98,11 @@ class Mailer {
 		$message = sanitize_textarea_field( $data['message'] ?? '' );
 		$source  = esc_url_raw( $data['source'] ?? '' );
 
+		$prefix = Settings::get( 'subject_prefix' );
+
 		$mail_subject = '' !== $subject
-			/* translators: %s: the visitor-supplied subject line. */
-			? sprintf( __( '[Contact] %s', 'fivetwofive-contact-form' ), $subject )
-			: __( '[Contact] New message from your website', 'fivetwofive-contact-form' );
+			? trim( $prefix . ' ' . $subject )
+			: trim( $prefix . ' ' . __( 'New message from your website', 'fivetwofive-contact-form' ) );
 
 		$lines = array(
 			/* translators: %s: sender name. */
@@ -122,12 +129,30 @@ class Mailer {
 		$body = implode( "\n", $lines );
 
 		// Reply-To the visitor so a reply in the inbox reaches them directly.
-		// From is deliberately left to the transport (a verified domain).
 		$headers = array();
 		if ( '' !== $email && is_email( $email ) ) {
 			$headers[] = '' !== $name
 				? sprintf( 'Reply-To: %s <%s>', $name, $email )
 				: sprintf( 'Reply-To: %s', $email );
+		}
+
+		// Optional From identity. Unset by default so the transport (e.g. a
+		// verified Postmark domain) supplies it; a transport with "force from"
+		// may override this regardless.
+		$from_email = Settings::get( 'from_email' );
+		if ( '' !== $from_email && is_email( $from_email ) ) {
+			$from_name = Settings::get( 'from_name' );
+			$headers[] = '' !== $from_name
+				? sprintf( 'From: %s <%s>', $from_name, $from_email )
+				: sprintf( 'From: %s', $from_email );
+		}
+
+		// Send as HTML when enabled. Escaping the assembled (visitor-supplied)
+		// body and converting newlines keeps it safe and preserves line breaks
+		// under transports that force an HTML body.
+		if ( '1' === Settings::get( 'html_email' ) ) {
+			$headers[] = 'Content-Type: text/html; charset=UTF-8';
+			$body      = nl2br( esc_html( $body ) );
 		}
 
 		return (bool) wp_mail( $to, $mail_subject, $body, $headers );


### PR DESCRIPTION
## Summary

- Adds a **Settings** submenu under the Contact Form (`ftf_submission`) menu so the notification recipient, sender identity, subject prefix, and notification format are configurable without code — implements #119.
- The Mailer reads these at send time. **Defaults preserve current behavior**: recipient falls back to the site admin email, the subject prefix stays `[Contact]`, and `From` is left to the transport unless set.
- New **"Send as HTML"** toggle escapes and `<br>`-converts the body — fixes the run-on rendering when a transport (e.g. Postmark) forces an HTML body / open-tracking.
- The setting is registered with a **typed `show_in_rest` schema**, so it's exposed on `/wp/v2/settings` (manage_options), self-validating, and block-editor friendly.
- Bumps the plugin to **1.1.0**.

## Decisions baked in

- **WordPress Settings API (server-rendered) over an ACF options page or a React screen.** Keeps the plugin dependency-light (no ACF requirement) and avoids adding a JS build pipeline for ~5 fields. React is reserved for when a richer settings UI justifies the tooling.
- **Modernized the Settings API usage rather than copying the `fivetwofive-cta` page.** Single typed option registered with `show_in_rest` + schema and a `sanitize` gate — cta's page had neither REST exposure nor a schema.
- **Single object option (`fivetwofive_contact_form_options`)** rather than one option per field — one `wp_options` row, and it's the exact key `uninstall.php` already removes.
- **Settings submenu under the Contact Form CPT menu** (not a new top-level menu like cta) since the CPT already owns a menu; settings sit next to the submissions inbox.
- **`From` left unset unless configured**, preserving the "leave it to the transport" default; a transport with force-from (Postmark) may override it regardless — noted in the field help.

## Test plan

- [x] `php -l` on all changed files — no syntax errors
- [x] Runtime (`wp eval`): `Admin\Settings` autoloads via PSR-4; `register_settings()` registers the setting + all 5 fields; REST schema exposes all 5 properties; `sanitize()` drops an invalid email while keeping valid fields
- [x] `Mailer->recipient()` falls back to the site admin email when the recipient is unset
- [x] New files confirmed git-tracked (deny-all `.gitignore` — `git check-ignore` clean)
- [ ] Manual admin smoke: open **Contact Form → Settings**, save valid + invalid values, confirm the saved/validation notices and persistence (recommended before merge)
- [ ] Manual: submit the form with **Send as HTML** on, confirm the Postmark notification renders with line breaks intact
- N/A — no SCSS/JS source change, so no theme asset rebuild. (WPCS/phpcs dev tooling isn't installed locally; PHP was hand-checked against the plugin's existing style + `php -l`.)

## Follow-ups

- Other #102 sub-issues add sections to this page later: Postmark token (#116), visitor auto-reply (#117), rate limiting (#100), Turnstile (#122).
- The HTML toggle is the lightweight fix for the plain-text-as-`HtmlBody` run-on captured in #102; Postmark hosted templates (#118) would later supersede it.

Closes #119
Refs #102