### PR TITLE
feat(theme): default module spacing to Medium framework-wide

### DIFF
--- a/wp-content/themes/fivetwofive-theme-child-editorial/functions.php
+++ b/wp-content/themes/fivetwofive-theme-child-editorial/functions.php
@@ -169,24 +169,3 @@ function fivetwofive_child_editorial_works_view_all( $url ) {
 	$page = get_page_by_path( 'editorial-case-studies' );
 	return $page ? get_permalink( $page ) : $url;
 }
-
-/**
- * Default the module spacing controls to "Medium".
- *
- * The parent's `spacing_top` / `spacing_bottom` button_group sub-fields default
- * to "None"; editorial modules want vertical breathing room by default, so
- * authors don't have to set Medium on every module. Scoped to this child — the
- * filter only loads while the editorial theme is active, leaving the portfolio's
- * "None" default untouched. Applies to new/unset modules only; saved values win.
- *
- * @param array $field ACF field definition.
- * @return array
- */
-add_filter( 'acf/load_field/name=spacing_top', 'fivetwofive_child_editorial_default_spacing' );
-add_filter( 'acf/load_field/name=spacing_bottom', 'fivetwofive_child_editorial_default_spacing' );
-function fivetwofive_child_editorial_default_spacing( $field ) {
-	if ( '' === $field['default_value'] || 'none' === $field['default_value'] ) {
-		$field['default_value'] = 'medium';
-	}
-	return $field;
-}

--- a/wp-content/themes/fivetwofive-theme-child-editorial/functions.php
+++ b/wp-content/themes/fivetwofive-theme-child-editorial/functions.php
@@ -169,3 +169,24 @@ function fivetwofive_child_editorial_works_view_all( $url ) {
 	$page = get_page_by_path( 'editorial-case-studies' );
 	return $page ? get_permalink( $page ) : $url;
 }
+
+/**
+ * Default the module spacing controls to "Medium".
+ *
+ * The parent's `spacing_top` / `spacing_bottom` button_group sub-fields default
+ * to "None"; editorial modules want vertical breathing room by default, so
+ * authors don't have to set Medium on every module. Scoped to this child — the
+ * filter only loads while the editorial theme is active, leaving the portfolio's
+ * "None" default untouched. Applies to new/unset modules only; saved values win.
+ *
+ * @param array $field ACF field definition.
+ * @return array
+ */
+add_filter( 'acf/load_field/name=spacing_top', 'fivetwofive_child_editorial_default_spacing' );
+add_filter( 'acf/load_field/name=spacing_bottom', 'fivetwofive_child_editorial_default_spacing' );
+function fivetwofive_child_editorial_default_spacing( $field ) {
+	if ( '' === $field['default_value'] || 'none' === $field['default_value'] ) {
+		$field['default_value'] = 'medium';
+	}
+	return $field;
+}

--- a/wp-content/themes/fivetwofive-theme-child-editorial/tools/build-editorial-content.php
+++ b/wp-content/themes/fivetwofive-theme-child-editorial/tools/build-editorial-content.php
@@ -264,6 +264,12 @@ foreach ( $pages as $slug => $spec ) {
 			'_wp_page_template' => $TEMPLATE,
 		),
 	) );
+	// Default every module to Medium top/bottom spacing (matches the editorial
+	// admin default); `+=` leaves any per-module override in place.
+	foreach ( $spec['modules'] as &$mod ) {
+		$mod += array( 'spacing_top' => 'medium', 'spacing_bottom' => 'medium' );
+	}
+	unset( $mod );
 	update_field( 'field_5c9b90b7e68cc', $spec['modules'], $pid );
 	$page_ids[ $slug ] = $pid;
 }

--- a/wp-content/themes/fivetwofive-theme/acf-json/group_5c9b8ee97b445.json
+++ b/wp-content/themes/fivetwofive-theme/acf-json/group_5c9b8ee97b445.json
@@ -296,7 +296,7 @@
                                 "medium": "Medium",
                                 "large": "Large"
                             },
-                            "default_value": "none",
+                            "default_value": "medium",
                             "return_format": "value",
                             "allow_null": 0,
                             "layout": "horizontal"
@@ -321,7 +321,7 @@
                                 "medium": "Medium",
                                 "large": "Large"
                             },
-                            "default_value": "none",
+                            "default_value": "medium",
                             "return_format": "value",
                             "allow_null": 0,
                             "layout": "horizontal"
@@ -921,7 +921,7 @@
                                 "medium": "Medium",
                                 "large": "Large"
                             },
-                            "default_value": "none",
+                            "default_value": "medium",
                             "return_format": "value",
                             "allow_null": 0,
                             "layout": "horizontal"
@@ -946,7 +946,7 @@
                                 "medium": "Medium",
                                 "large": "Large"
                             },
-                            "default_value": "none",
+                            "default_value": "medium",
                             "return_format": "value",
                             "allow_null": 0,
                             "layout": "horizontal"
@@ -1446,7 +1446,7 @@
                                 "medium": "Medium",
                                 "large": "Large"
                             },
-                            "default_value": "none",
+                            "default_value": "medium",
                             "return_format": "value",
                             "allow_null": 0,
                             "layout": "horizontal"
@@ -1471,7 +1471,7 @@
                                 "medium": "Medium",
                                 "large": "Large"
                             },
-                            "default_value": "none",
+                            "default_value": "medium",
                             "return_format": "value",
                             "allow_null": 0,
                             "layout": "horizontal"
@@ -1975,7 +1975,7 @@
                                 "medium": "Medium",
                                 "large": "Large"
                             },
-                            "default_value": "none",
+                            "default_value": "medium",
                             "return_format": "value",
                             "allow_null": 0,
                             "layout": "horizontal"
@@ -2000,7 +2000,7 @@
                                 "medium": "Medium",
                                 "large": "Large"
                             },
-                            "default_value": "none",
+                            "default_value": "medium",
                             "return_format": "value",
                             "allow_null": 0,
                             "layout": "horizontal"
@@ -2774,7 +2774,7 @@
                                 "medium": "Medium",
                                 "large": "Large"
                             },
-                            "default_value": "none",
+                            "default_value": "medium",
                             "return_format": "value",
                             "allow_null": 0,
                             "layout": "horizontal"
@@ -2799,7 +2799,7 @@
                                 "medium": "Medium",
                                 "large": "Large"
                             },
-                            "default_value": "none",
+                            "default_value": "medium",
                             "return_format": "value",
                             "allow_null": 0,
                             "layout": "horizontal"
@@ -3527,7 +3527,7 @@
                                 "medium": "Medium",
                                 "large": "Large"
                             },
-                            "default_value": "none",
+                            "default_value": "medium",
                             "return_format": "value",
                             "allow_null": 0,
                             "layout": "horizontal"
@@ -3552,7 +3552,7 @@
                                 "medium": "Medium",
                                 "large": "Large"
                             },
-                            "default_value": "none",
+                            "default_value": "medium",
                             "return_format": "value",
                             "allow_null": 0,
                             "layout": "horizontal"
@@ -4133,7 +4133,7 @@
                                 "medium": "Medium",
                                 "large": "Large"
                             },
-                            "default_value": "none",
+                            "default_value": "medium",
                             "return_format": "value",
                             "allow_null": 0,
                             "layout": "horizontal"
@@ -4158,7 +4158,7 @@
                                 "medium": "Medium",
                                 "large": "Large"
                             },
-                            "default_value": "none",
+                            "default_value": "medium",
                             "return_format": "value",
                             "allow_null": 0,
                             "layout": "horizontal"
@@ -4926,7 +4926,7 @@
                                 "medium": "Medium",
                                 "large": "Large"
                             },
-                            "default_value": "none",
+                            "default_value": "medium",
                             "return_format": "value",
                             "allow_null": 0,
                             "layout": "horizontal"
@@ -4951,7 +4951,7 @@
                                 "medium": "Medium",
                                 "large": "Large"
                             },
-                            "default_value": "none",
+                            "default_value": "medium",
                             "return_format": "value",
                             "allow_null": 0,
                             "layout": "horizontal"
@@ -5599,7 +5599,7 @@
                                 "medium": "Medium",
                                 "large": "Large"
                             },
-                            "default_value": "none",
+                            "default_value": "medium",
                             "return_format": "value",
                             "allow_null": 0,
                             "layout": "horizontal"
@@ -5624,7 +5624,7 @@
                                 "medium": "Medium",
                                 "large": "Large"
                             },
-                            "default_value": "none",
+                            "default_value": "medium",
                             "return_format": "value",
                             "allow_null": 0,
                             "layout": "horizontal"
@@ -6188,7 +6188,7 @@
                                 "medium": "Medium",
                                 "large": "Large"
                             },
-                            "default_value": "none",
+                            "default_value": "medium",
                             "return_format": "value",
                             "allow_null": 0,
                             "layout": "horizontal"
@@ -6213,7 +6213,7 @@
                                 "medium": "Medium",
                                 "large": "Large"
                             },
-                            "default_value": "none",
+                            "default_value": "medium",
                             "return_format": "value",
                             "allow_null": 0,
                             "layout": "horizontal"
@@ -6882,7 +6882,7 @@
                                 "medium": "Medium",
                                 "large": "Large"
                             },
-                            "default_value": "none",
+                            "default_value": "medium",
                             "return_format": "value",
                             "allow_null": 0,
                             "layout": "horizontal"
@@ -6907,7 +6907,7 @@
                                 "medium": "Medium",
                                 "large": "Large"
                             },
-                            "default_value": "none",
+                            "default_value": "medium",
                             "return_format": "value",
                             "allow_null": 0,
                             "layout": "horizontal"
@@ -7505,7 +7505,7 @@
                                 "medium": "Medium",
                                 "large": "Large"
                             },
-                            "default_value": "none",
+                            "default_value": "medium",
                             "return_format": "value",
                             "allow_null": 0,
                             "layout": "horizontal"
@@ -7530,7 +7530,7 @@
                                 "medium": "Medium",
                                 "large": "Large"
                             },
-                            "default_value": "none",
+                            "default_value": "medium",
                             "return_format": "value",
                             "allow_null": 0,
                             "layout": "horizontal"
@@ -7916,5 +7916,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1781824131
+    "modified": 1782453511
 }


### PR DESCRIPTION
## Summary

- Makes **Medium** the default for the modules' `spacing_top` / `spacing_bottom` button_group fields **framework-wide**, in the parent's modules ACF JSON — so new modules on **any** theme (portfolio and editorial) get vertical breathing room by default instead of None.
- The content build script also sets Medium explicitly, so the reproducible editorial pages are deterministic.

## Decisions baked in

- **Parent ACF default, not a child filter.** Requested portfolio-wide, so it's a framework-level default in `acf-json/group_5c9b8ee97b445.json` rather than an editorial-child `acf/load_field` filter. (An earlier commit on this branch took the child-scoped approach; it was removed once the scope became global — the "fix it upstream, retire the workaround" move.)
- **Defaults only, never overrides.** ACF applies `default_value` only to new/unset fields — every existing module on the portfolio and editorial sites keeps its saved spacing. Zero retroactive change.
- **Surgical JSON edit.** Python round-trip (indent=4 + escaped slashes = byte-identical formatting) so the diff is exactly the 24 `default_value` flips (12 layouts × top/bottom) + the `modified` bump — no reformatting noise.

## Test plan

- [x] `php -l` clean on `functions.php` (reverted to net-zero) and the build script
- [x] No asset rebuild — ACF-JSON + PHP only
- [x] With the child filter **removed**, `acf_get_field('spacing_top'|'spacing_bottom')['default_value']` → `medium` — proving the parent JSON now drives the default
- [x] JSON diff verified: only 24 `"default_value": "none"` → `"medium"` lines + `modified` timestamp
- [x] Re-ran the build script — editorial pages still render `ftf-module--spacing-{top,bottom}-medium`
- [ ] Admin click-test: open a new module's Appearance tab (on either theme) and confirm Medium is preselected — verified programmatically; quick to eyeball live

## Follow-ups

- ACF will show **"Sync available"** on the Field Groups screen (JSON is newer than the DB copy). The default already works at runtime (ACF loads the local JSON), so syncing is optional housekeeping to bring the DB record in line.