### PR TITLE
fix(contact-form): default notification email to HTML (#155)

### DIFF
--- a/wp-content/plugins/fivetwofive-contact-form/fivetwofive-contact-form.php
+++ b/wp-content/plugins/fivetwofive-contact-form/fivetwofive-contact-form.php
@@ -11,7 +11,7 @@
  * Plugin Name:       FiveTwoFive Contact Form
  * Plugin URI:        https://fivetwofive.com/
  * Description:       A lightweight, dependency-light contact form. Stores every submission as a record and sends notifications via wp_mail() with a swappable mail transport.
- * Version:           1.1.0
+ * Version:           1.1.1
  * Requires at least: 5.2
  * Requires PHP:      7.4
  * Author:            FiveTwoFive Creative Team
@@ -27,7 +27,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Current plugin version.
  */
-define( 'FTF_CONTACT_FORM_VERSION', '1.1.0' );
+define( 'FTF_CONTACT_FORM_VERSION', '1.1.1' );
 
 if ( ! defined( 'FTF_CONTACT_FORM_PLUGIN_FILE' ) ) {
 	define( 'FTF_CONTACT_FORM_PLUGIN_FILE', __FILE__ );

--- a/wp-content/plugins/fivetwofive-contact-form/src/Admin/Settings.php
+++ b/wp-content/plugins/fivetwofive-contact-form/src/Admin/Settings.php
@@ -92,6 +92,12 @@ class Settings {
 	 * recipient falls back to the site admin email, the From identity falls
 	 * back to the transport's default.
 	 *
+	 * `html_email` defaults to '1' so notifications render correctly under
+	 * transports that force an HTML body (e.g. Postmark), where plain-text line
+	 * breaks would otherwise collapse into a single run-on line. This default
+	 * only governs installs that have never saved settings — get() returns a
+	 * stored '0'/'1' ahead of the default, so an existing opt-out is preserved.
+	 *
 	 * @since  1.1.0
 	 * @return array
 	 */
@@ -101,7 +107,7 @@ class Settings {
 			'from_name'      => '',
 			'from_email'     => '',
 			'subject_prefix' => '[Contact]',
-			'html_email'     => '0',
+			'html_email'     => '1',
 		);
 	}
 
@@ -273,7 +279,7 @@ class Settings {
 			array(
 				'id'          => 'html_email',
 				'label'       => __( 'Send the notification as HTML', 'fivetwofive-contact-form' ),
-				'description' => __( 'Recommended when a transport forces HTML or open-tracking (e.g. Postmark) — otherwise the plain-text line breaks collapse into a single run-on line.', 'fivetwofive-contact-form' ),
+				'description' => __( 'On by default so line breaks survive transports that force HTML or open-tracking (e.g. Postmark). Uncheck to send the notification as plain text instead.', 'fivetwofive-contact-form' ),
 			)
 		);
 	}


### PR DESCRIPTION
## Summary

- Flip the `html_email` setting default from off to on, so a fresh install sends the admin notification as HTML by default.
- Fixes the run-on blob: under a transport that forces an HTML body (Postmark with Force HTML / open-tracking), a plain-text notification's `\n` line breaks were copied into `HtmlBody` unconverted and collapsed into one line. The HTML branch (`Content-Type: text/html` + `nl2br( esc_html() )`) already shipped in #123 — this just makes it the default.
- Plugin-only PHP change; bumps the plugin to **1.1.1**. No theme assets touched.

## Decisions baked in

- **Flip the default rather than auto-detect a force-HTML transport.** Postmark's `force_html` is a Postmark-plugin option with no clean, provider-agnostic introspection point, so detection would be brittle and Postmark-specific. A plain default flip is simpler and transport-neutral.
- **Document the existing-install nuance instead of migrating.** `get()` returns a stored `'0'`/`'1'` ahead of the default (strict `'' !== $value`, so `'0'` counts as a real stored value), so already-saved sites keep their choice — only never-saved installs are affected. A migration could override a deliberate opt-out. Production already has the box on, so it's unaffected either way.
- **HTML stays escape-safe.** The body is `nl2br( esc_html( $body ) )` built from already-sanitized fields, so defaulting HTML on adds no injection surface.

## Test plan

- [x] `php -l` on both changed files — no syntax errors
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist` on both changed files — 0 violations
- [x] Traced `Settings::get('html_email')` across all three states: fresh install → `'1'` (HTML); saved `'0'` → preserved (plain text); saved `'1'` (production) → unchanged — confirming the flip only affects never-saved installs
- [x] Confirmed the admin "Send as HTML" checkbox renders checked on a fresh install (`field_checkbox` reads `get_option( OPTION, self::defaults() )`)
- [ ] Not run: live LocalWP submission — verification was static + code-trace; the fresh-install default can't be exercised without deleting the saved option on the shared local DB, and the HTML branch it enables is already the path running in production

## Follow-ups

- Closes #155. Part of epic #102.
- Operator note: existing sites that previously saved settings with the box unchecked keep plain text — tick **Contact Form → Settings → Send as HTML** to switch. Production already has it enabled.