### PR TITLE
fix(contact-form): i18n + honeypot hardening (#98, #101)

### DIFF
--- a/wp-content/plugins/fivetwofive-contact-form/fivetwofive-contact-form.php
+++ b/wp-content/plugins/fivetwofive-contact-form/fivetwofive-contact-form.php
@@ -11,7 +11,7 @@
  * Plugin Name:       FiveTwoFive Contact Form
  * Plugin URI:        https://fivetwofive.com/
  * Description:       A lightweight, dependency-light contact form. Stores every submission as a record and sends notifications via wp_mail() with a swappable mail transport.
- * Version:           1.1.1
+ * Version:           1.1.2
  * Requires at least: 5.2
  * Requires PHP:      7.4
  * Author:            FiveTwoFive Creative Team
@@ -27,7 +27,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Current plugin version.
  */
-define( 'FTF_CONTACT_FORM_VERSION', '1.1.1' );
+define( 'FTF_CONTACT_FORM_VERSION', '1.1.2' );
 
 if ( ! defined( 'FTF_CONTACT_FORM_PLUGIN_FILE' ) ) {
 	define( 'FTF_CONTACT_FORM_PLUGIN_FILE', __FILE__ );

--- a/wp-content/plugins/fivetwofive-contact-form/includes/class-fivetwofive-contact-form.php
+++ b/wp-content/plugins/fivetwofive-contact-form/includes/class-fivetwofive-contact-form.php
@@ -114,6 +114,12 @@ class FiveTwoFive_Contact_Form {
 	 * @since 1.0.0
 	 */
 	private function define_public_hooks(): void {
+		// Load translations. The header declares Domain Path: /languages, but WP
+		// never loads a catalog from a plugin's own folder without this call
+		// (its just-in-time loader only scans wp-content/languages/plugins/).
+		// Hooked to init — WP 6.7+ warns when a text domain loads earlier.
+		add_action( 'init', array( $this, 'load_textdomain' ) );
+
 		// The submissions post type must exist on every request (the front-end
 		// submit handler writes to it), so it registers on the shared init hook.
 		add_action( 'init', array( $this->submission, 'register' ) );
@@ -149,6 +155,24 @@ class FiveTwoFive_Contact_Form {
 		// define_public_hooks() — so it also applies to REST requests.
 		add_action( 'admin_menu', array( $this->settings, 'add_menu' ) );
 		add_action( 'admin_init', array( $this->settings, 'register_fields' ) );
+	}
+
+	/**
+	 * Load the plugin text domain so translations in /languages are honored.
+	 *
+	 * The plugin header declares `Domain Path: /languages`; without this call
+	 * WordPress loads no plugin-supplied catalog from that folder (its
+	 * just-in-time loader only scans wp-content/languages/plugins/). Hooked to
+	 * `init` — WP 6.7+ emits a notice when a text domain loads earlier.
+	 *
+	 * @since 1.1.2
+	 */
+	public function load_textdomain(): void {
+		load_plugin_textdomain(
+			'fivetwofive-contact-form',
+			false,
+			dirname( plugin_basename( FTF_CONTACT_FORM_PLUGIN_FILE ) ) . '/languages'
+		);
 	}
 
 	/**

--- a/wp-content/plugins/fivetwofive-contact-form/languages/fivetwofive-contact-form.pot
+++ b/wp-content/plugins/fivetwofive-contact-form/languages/fivetwofive-contact-form.pot
@@ -1,0 +1,289 @@
+# Copyright (C) 2026 FiveTwoFive Creative Team
+# This file is distributed under the GPL v2 or later.
+msgid ""
+msgstr ""
+"Project-Id-Version: FiveTwoFive Contact Form 1.1.2\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/fivetwofive-contact-form\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2026-07-10T00:48:09+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: fivetwofive-contact-form\n"
+
+#. Plugin Name of the plugin
+#: fivetwofive-contact-form.php
+msgid "FiveTwoFive Contact Form"
+msgstr ""
+
+#. Plugin URI of the plugin
+#. Author URI of the plugin
+#: fivetwofive-contact-form.php
+msgid "https://fivetwofive.com/"
+msgstr ""
+
+#. Description of the plugin
+#: fivetwofive-contact-form.php
+msgid "A lightweight, dependency-light contact form. Stores every submission as a record and sends notifications via wp_mail() with a swappable mail transport."
+msgstr ""
+
+#. Author of the plugin
+#: fivetwofive-contact-form.php
+msgid "FiveTwoFive Creative Team"
+msgstr ""
+
+#: fivetwofive-contact-form.php:51
+msgid "FiveTwoFive Contact Form is missing its autoloader. Run \"composer install\" in the plugin directory."
+msgstr ""
+
+#: resources/views/admin/settings-page.php:21
+msgid "Settings saved."
+msgstr ""
+
+#: resources/views/frontend/contact-form.php:35
+#: src/Form/Handler.php:205
+msgid "Thanks — your message has been sent."
+msgstr ""
+
+#: resources/views/frontend/contact-form.php:39
+msgid "Sorry, your message could not be sent. Please try again."
+msgstr ""
+
+#: resources/views/frontend/contact-form.php:52
+msgid "Leave this field empty"
+msgstr ""
+
+#: resources/views/frontend/contact-form.php:59
+#: src/PostType/Submission.php:347
+msgid "Name"
+msgstr ""
+
+#: resources/views/frontend/contact-form.php:67
+#: src/PostType/Submission.php:244
+#: src/PostType/Submission.php:348
+msgid "Email"
+msgstr ""
+
+#: resources/views/frontend/contact-form.php:74
+#: src/PostType/Submission.php:245
+#: src/PostType/Submission.php:351
+msgid "Subject"
+msgstr ""
+
+#: resources/views/frontend/contact-form.php:80
+#: src/PostType/Submission.php:369
+msgid "Message"
+msgstr ""
+
+#: resources/views/frontend/contact-form.php:88
+msgid "Send Message"
+msgstr ""
+
+#: src/Admin/Settings.php:150
+msgid "Contact Form Settings"
+msgstr ""
+
+#: src/Admin/Settings.php:151
+msgid "Settings"
+msgstr ""
+
+#: src/Admin/Settings.php:214
+msgid "Notifications"
+msgstr ""
+
+#: src/Admin/Settings.php:221
+msgid "Notification recipient"
+msgstr ""
+
+#: src/Admin/Settings.php:229
+msgid "Where submission notifications are sent. Leave blank to use the site admin email."
+msgstr ""
+
+#: src/Admin/Settings.php:235
+msgid "Sender name"
+msgstr ""
+
+#: src/Admin/Settings.php:242
+msgid "Optional \"From\" name on the notification."
+msgstr ""
+
+#: src/Admin/Settings.php:248
+msgid "Sender email (From)"
+msgstr ""
+
+#: src/Admin/Settings.php:255
+msgid "Optional \"From\" address. Leave blank to let the mail transport set it. A transport like Postmark with \"force from\" enabled may override this."
+msgstr ""
+
+#: src/Admin/Settings.php:261
+msgid "Subject prefix"
+msgstr ""
+
+#: src/Admin/Settings.php:269
+msgid "Prepended to the notification subject line."
+msgstr ""
+
+#: src/Admin/Settings.php:275
+msgid "Send as HTML"
+msgstr ""
+
+#: src/Admin/Settings.php:281
+msgid "Send the notification as HTML"
+msgstr ""
+
+#: src/Admin/Settings.php:282
+msgid "On by default so line breaks survive transports that force HTML or open-tracking (e.g. Postmark). Uncheck to send the notification as plain text instead."
+msgstr ""
+
+#. translators: %s: the contact form shortcode, wrapped in a <code> tag.
+#: src/Admin/Settings.php:297
+#, php-format
+msgid "Use the shortcode %s to display the contact form on a page or post. The settings below control where submissions are sent and how the notification email is addressed and formatted."
+msgstr ""
+
+#: src/Admin/Settings.php:347
+msgid "The notification recipient must be a valid email address."
+msgstr ""
+
+#: src/Admin/Settings.php:352
+msgid "The sender email must be a valid email address."
+msgstr ""
+
+#: src/Form/Handler.php:85
+msgid "Your session expired. Please reload the page and try again."
+msgstr ""
+
+#: src/Form/Handler.php:105
+msgid "That looked a little too quick — please take a moment and send your message again."
+msgstr ""
+
+#: src/Form/Handler.php:119
+msgid "Please enter your name."
+msgstr ""
+
+#: src/Form/Handler.php:123
+msgid "Please enter a valid email address."
+msgstr ""
+
+#: src/Form/Handler.php:127
+msgid "Please enter a message."
+msgstr ""
+
+#: src/Form/Handler.php:135
+msgid "One or more fields are too long."
+msgstr ""
+
+#: src/Form/Handler.php:156
+msgid "Something went wrong saving your message. Please try again."
+msgstr ""
+
+#: src/Frontend/Shortcode.php:92
+msgid "Sorry, something went wrong. Please try again."
+msgstr ""
+
+#: src/Mailer/Mailer.php:105
+msgid "New message from your website"
+msgstr ""
+
+#. translators: %s: sender name.
+#: src/Mailer/Mailer.php:109
+#, php-format
+msgid "Name: %s"
+msgstr ""
+
+#. translators: %s: sender email.
+#: src/Mailer/Mailer.php:111
+#, php-format
+msgid "Email: %s"
+msgstr ""
+
+#. translators: %s: subject line.
+#: src/Mailer/Mailer.php:116
+#, php-format
+msgid "Subject: %s"
+msgstr ""
+
+#: src/Mailer/Mailer.php:120
+msgid "Message:"
+msgstr ""
+
+#. translators: %s: URL the form was submitted from.
+#: src/Mailer/Mailer.php:126
+#, php-format
+msgid "Sent from: %s"
+msgstr ""
+
+#: src/PostType/Submission.php:106
+msgctxt "post type general name"
+msgid "Submissions"
+msgstr ""
+
+#: src/PostType/Submission.php:107
+msgctxt "post type singular name"
+msgid "Submission"
+msgstr ""
+
+#: src/PostType/Submission.php:108
+msgctxt "admin menu"
+msgid "Contact Form"
+msgstr ""
+
+#: src/PostType/Submission.php:109
+msgid "Submissions"
+msgstr ""
+
+#: src/PostType/Submission.php:110
+#: src/PostType/Submission.php:111
+msgid "View Submission"
+msgstr ""
+
+#: src/PostType/Submission.php:112
+msgid "Search Submissions"
+msgstr ""
+
+#: src/PostType/Submission.php:113
+msgid "No submissions found."
+msgstr ""
+
+#: src/PostType/Submission.php:114
+msgid "No submissions found in Trash."
+msgstr ""
+
+#: src/PostType/Submission.php:181
+msgid "Anonymous"
+msgstr ""
+
+#. translators: 1: sender name, 2: submission date.
+#: src/PostType/Submission.php:185
+#, php-format
+msgctxt "submission list title"
+msgid "%1$s — %2$s"
+msgstr ""
+
+#: src/PostType/Submission.php:246
+#: src/PostType/Submission.php:356
+msgid "Notification"
+msgstr ""
+
+#: src/PostType/Submission.php:306
+msgid "Sent"
+msgstr ""
+
+#: src/PostType/Submission.php:307
+msgid "Failed"
+msgstr ""
+
+#: src/PostType/Submission.php:323
+msgid "Submission Details"
+msgstr ""
+
+#: src/PostType/Submission.php:352
+msgid "Submitted"
+msgstr ""
+
+#: src/PostType/Submission.php:353
+msgid "Source page"
+msgstr ""

--- a/wp-content/plugins/fivetwofive-contact-form/resources/views/frontend/contact-form.php
+++ b/wp-content/plugins/fivetwofive-contact-form/resources/views/frontend/contact-form.php
@@ -13,6 +13,19 @@ defined( 'ABSPATH' ) || exit;
 ?>
 <div class="ftf-contact-form-wrap">
 
+	<?php
+	/*
+	 * Critical inline style — hides the honeypot at first paint so it is never
+	 * briefly visible before the stylesheet applies. The stylesheet is
+	 * conditionally enqueued from the shortcode and therefore prints in the
+	 * footer, leaving a short window where an external-CSS-only rule would not
+	 * yet apply. This mirrors the .ftf-contact-form__hp rule in
+	 * fivetwofive-contact-form.css, is placement-independent, and survives the
+	 * module kses path (which permits the <style> element). See #101.
+	 */
+	?>
+	<style>.ftf-contact-form__hp{position:absolute!important;left:-9999px!important;width:1px;height:1px;overflow:hidden;}</style>
+
 	<?php if ( '' !== $ftf['title'] ) : ?>
 		<h2 class="ftf-contact-form__title"><?php echo esc_html( $ftf['title'] ); ?></h2>
 	<?php endif; ?>


### PR DESCRIPTION
## Summary

- Two small contact-form hygiene fixes shipped together as **v1.1.2**, one commit each.
- **#98 (i18n):** wire up `load_plugin_textdomain()` on `init` and ship a generated `.pot`, so the declared `Domain Path: /languages` actually works — it was non-functional (a catalog dropped into `languages/` would silently never load).
- **#101 (honeypot):** emit a tiny inline `<style>` that hides the honeypot at first paint, so it is never briefly visible in the window before the (footer-loaded) stylesheet applies.

## Decisions baked in

- **#101 — inline `<style>`, not early head-enqueue.** The issue's Option 1 (detect the shortcode early via `has_shortcode()` and enqueue in `<head>`) is a **no-op for this site's real placement**: the form is embedded via the ACF Multi-Column module (#103), so its markup lives in ACF meta, not `post_content`, and early detection never fires. Inline critical CSS decouples the honeypot from stylesheet timing regardless of placement. Verified it survives `wp_kses( …, fivetwofive_kses_extended_ruleset() )` — the ruleset permits the `<style>` *element*, whereas a `style` *attribute* could be stripped by `safecss_filter_attr` (e.g. `position`).
- **#101 — whole-form FOUC left as accepted-cosmetic.** Conditional footer-loading of the full stylesheet is intentional (assets load only where the form is; the sibling CTA plugin uses the same pattern). Only the honeypot — the one non-cosmetic concern (P4, risk ≈ 0) — is decoupled. Removing all FOUC would mean unconditional site-wide head-loading, trading away that optimization.
- **#98 — make the mechanism work, not drop the header.** Chose `load_plugin_textdomain()` + `.pot` over the alternative (deleting the misleading `Domain Path` header). Every string is already wrapped, so translatability is clearly intended. Hooked on `init` (WP 6.7+ warns when a text domain loads earlier).
- **CTA #82 left out of scope.** #98 is the twin of the still-open CTA finding #82; fixing CTA here would scope-creep. The same fix applies there when #82 is picked up.

## Test plan

- [x] `php -l` clean on all 3 changed PHP files
- [x] `phpcs --standard=phpcs.xml.dist` — 0 violations on all changed PHP + the view
- [x] Runtime render on LocalWP (`jabaltorres.local`, plugin active): shortcode output contains the `<style>` and it precedes the honeypot field
- [x] Runtime kses check: the `<style>` and its exact rule survive `wp_kses( …, fivetwofive_kses_extended_ruleset() )` — i.e. the ACF-module placement
- [x] Runtime: `load_textdomain` method exists, `init` hook registered, `is_textdomain_loaded()` returns `false` with no fatal (no `.mo` yet, expected); `FTF_CONTACT_FORM_VERSION` = 1.1.2
- [x] `.pot` generated via `wp i18n make-pot` — relative file refs (no machine paths), only standard POT placeholders (no PII), Project-Id-Version 1.1.2
- [x] No SCSS/JS source touched — plugin CSS is hand-written (no gulp build); change is PHP/markup only

## Follow-ups

- Closes #98 and #101. Part of epic #102.
- #82 — the CTA plugin has the identical i18n gap; this PR's #98 fix applies there too. Still open, out of scope here.
- Whole-form FOUC on ACF-module placements is intentionally not addressed (see Decisions); the honeypot exposure — the only non-cosmetic part — is fixed everywhere.