### PR TITLE
feat(contact-form): opt-in visitor auto-reply (#117)

### DIFF
--- a/wp-content/plugins/fivetwofive-contact-form/fivetwofive-contact-form.php
+++ b/wp-content/plugins/fivetwofive-contact-form/fivetwofive-contact-form.php
@@ -11,7 +11,7 @@
  * Plugin Name:       FiveTwoFive Contact Form
  * Plugin URI:        https://fivetwofive.com/
  * Description:       A lightweight, dependency-light contact form. Stores every submission as a record and sends notifications via wp_mail() with a swappable mail transport.
- * Version:           1.1.2
+ * Version:           1.2.0
  * Requires at least: 5.2
  * Requires PHP:      7.4
  * Author:            FiveTwoFive Creative Team
@@ -27,7 +27,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Current plugin version.
  */
-define( 'FTF_CONTACT_FORM_VERSION', '1.1.2' );
+define( 'FTF_CONTACT_FORM_VERSION', '1.2.0' );
 
 if ( ! defined( 'FTF_CONTACT_FORM_PLUGIN_FILE' ) ) {
 	define( 'FTF_CONTACT_FORM_PLUGIN_FILE', __FILE__ );

--- a/wp-content/plugins/fivetwofive-contact-form/languages/fivetwofive-contact-form.pot
+++ b/wp-content/plugins/fivetwofive-contact-form/languages/fivetwofive-contact-form.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: FiveTwoFive Contact Form 1.1.2\n"
+"Project-Id-Version: FiveTwoFive Contact Form 1.2.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/fivetwofive-contact-form\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-10T00:48:09+00:00\n"
+"POT-Creation-Date: 2026-07-11T04:33:07+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: fivetwofive-contact-form\n"
@@ -44,7 +44,7 @@ msgid "Settings saved."
 msgstr ""
 
 #: resources/views/frontend/contact-form.php:35
-#: src/Form/Handler.php:205
+#: src/Form/Handler.php:235
 msgid "Thanks — your message has been sent."
 msgstr ""
 
@@ -82,101 +82,139 @@ msgstr ""
 msgid "Send Message"
 msgstr ""
 
-#: src/Admin/Settings.php:150
+#: src/Admin/Settings.php:160
 msgid "Contact Form Settings"
 msgstr ""
 
-#: src/Admin/Settings.php:151
+#: src/Admin/Settings.php:161
 msgid "Settings"
 msgstr ""
 
-#: src/Admin/Settings.php:214
+#: src/Admin/Settings.php:230
 msgid "Notifications"
 msgstr ""
 
-#: src/Admin/Settings.php:221
+#: src/Admin/Settings.php:237
 msgid "Notification recipient"
 msgstr ""
 
-#: src/Admin/Settings.php:229
+#: src/Admin/Settings.php:245
 msgid "Where submission notifications are sent. Leave blank to use the site admin email."
 msgstr ""
 
-#: src/Admin/Settings.php:235
+#: src/Admin/Settings.php:251
 msgid "Sender name"
 msgstr ""
 
-#: src/Admin/Settings.php:242
+#: src/Admin/Settings.php:258
 msgid "Optional \"From\" name on the notification."
 msgstr ""
 
-#: src/Admin/Settings.php:248
+#: src/Admin/Settings.php:264
 msgid "Sender email (From)"
 msgstr ""
 
-#: src/Admin/Settings.php:255
+#: src/Admin/Settings.php:271
 msgid "Optional \"From\" address. Leave blank to let the mail transport set it. A transport like Postmark with \"force from\" enabled may override this."
 msgstr ""
 
-#: src/Admin/Settings.php:261
+#: src/Admin/Settings.php:277
 msgid "Subject prefix"
 msgstr ""
 
-#: src/Admin/Settings.php:269
+#: src/Admin/Settings.php:285
 msgid "Prepended to the notification subject line."
 msgstr ""
 
-#: src/Admin/Settings.php:275
+#: src/Admin/Settings.php:291
 msgid "Send as HTML"
 msgstr ""
 
-#: src/Admin/Settings.php:281
+#: src/Admin/Settings.php:297
 msgid "Send the notification as HTML"
 msgstr ""
 
-#: src/Admin/Settings.php:282
+#: src/Admin/Settings.php:298
 msgid "On by default so line breaks survive transports that force HTML or open-tracking (e.g. Postmark). Uncheck to send the notification as plain text instead."
 msgstr ""
 
+#: src/Admin/Settings.php:304
+#: src/Admin/Settings.php:311
+msgid "Auto-reply"
+msgstr ""
+
+#: src/Admin/Settings.php:317
+msgid "Send a confirmation email to the visitor"
+msgstr ""
+
+#: src/Admin/Settings.php:318
+msgid "Off by default. Enable only when an authenticated transport (e.g. Postmark) is configured — an unauthenticated confirmation to an external inbox will be spam-filtered."
+msgstr ""
+
+#: src/Admin/Settings.php:324
+msgid "Auto-reply subject"
+msgstr ""
+
+#: src/Admin/Settings.php:331
+#: src/Mailer/Mailer.php:183
+msgid "Thanks for your message"
+msgstr ""
+
+#: src/Admin/Settings.php:332
+msgid "Subject line of the confirmation. Leave blank for the default."
+msgstr ""
+
+#: src/Admin/Settings.php:338
+msgid "Auto-reply message"
+msgstr ""
+
+#: src/Admin/Settings.php:344
+msgid "Body of the confirmation. Leave blank for the default. Placeholders: {name} (the visitor) and {site_name}."
+msgstr ""
+
 #. translators: %s: the contact form shortcode, wrapped in a <code> tag.
-#: src/Admin/Settings.php:297
+#: src/Admin/Settings.php:359
 #, php-format
 msgid "Use the shortcode %s to display the contact form on a page or post. The settings below control where submissions are sent and how the notification email is addressed and formatted."
 msgstr ""
 
-#: src/Admin/Settings.php:347
+#: src/Admin/Settings.php:373
+msgid "Optionally send the visitor a branded confirmation after they submit. It goes to an external inbox, so enable it only with an authenticated transport (e.g. Postmark) — otherwise leave it off."
+msgstr ""
+
+#: src/Admin/Settings.php:433
 msgid "The notification recipient must be a valid email address."
 msgstr ""
 
-#: src/Admin/Settings.php:352
+#: src/Admin/Settings.php:438
 msgid "The sender email must be a valid email address."
 msgstr ""
 
-#: src/Form/Handler.php:85
+#: src/Form/Handler.php:86
 msgid "Your session expired. Please reload the page and try again."
 msgstr ""
 
-#: src/Form/Handler.php:105
+#: src/Form/Handler.php:106
 msgid "That looked a little too quick — please take a moment and send your message again."
 msgstr ""
 
-#: src/Form/Handler.php:119
+#: src/Form/Handler.php:120
 msgid "Please enter your name."
 msgstr ""
 
-#: src/Form/Handler.php:123
+#: src/Form/Handler.php:124
 msgid "Please enter a valid email address."
 msgstr ""
 
-#: src/Form/Handler.php:127
+#: src/Form/Handler.php:128
 msgid "Please enter a message."
 msgstr ""
 
-#: src/Form/Handler.php:135
+#: src/Form/Handler.php:136
 msgid "One or more fields are too long."
 msgstr ""
 
-#: src/Form/Handler.php:156
+#: src/Form/Handler.php:157
 msgid "Something went wrong saving your message. Please try again."
 msgstr ""
 
@@ -214,6 +252,19 @@ msgstr ""
 #: src/Mailer/Mailer.php:126
 #, php-format
 msgid "Sent from: %s"
+msgstr ""
+
+#: src/Mailer/Mailer.php:177
+msgid "there"
+msgstr ""
+
+#: src/Mailer/Mailer.php:260
+msgid ""
+"Hi {name},\n"
+"\n"
+"Thanks for getting in touch. I've received your message and will get back to you as soon as I can.\n"
+"\n"
+"— {site_name}"
 msgstr ""
 
 #: src/PostType/Submission.php:106

--- a/wp-content/plugins/fivetwofive-contact-form/src/Admin/Settings.php
+++ b/wp-content/plugins/fivetwofive-contact-form/src/Admin/Settings.php
@@ -55,6 +55,13 @@ class Settings {
 	private const SECTION = 'ftf_contact_form_notification';
 
 	/**
+	 * Auto-reply settings section id.
+	 *
+	 * @var string
+	 */
+	private const SECTION_AUTOREPLY = 'ftf_contact_form_autoreply';
+
+	/**
 	 * Admin notice group for settings errors. Public so the page view can pass
 	 * it to settings_errors().
 	 *
@@ -103,11 +110,14 @@ class Settings {
 	 */
 	public static function defaults(): array {
 		return array(
-			'recipient'      => '',
-			'from_name'      => '',
-			'from_email'     => '',
-			'subject_prefix' => '[Contact]',
-			'html_email'     => '1',
+			'recipient'         => '',
+			'from_name'         => '',
+			'from_email'        => '',
+			'subject_prefix'    => '[Contact]',
+			'html_email'        => '1',
+			'autoreply_enable'  => '0',
+			'autoreply_subject' => '',
+			'autoreply_body'    => '',
 		);
 	}
 
@@ -186,14 +196,20 @@ class Settings {
 					'schema' => array(
 						'type'                 => 'object',
 						'properties'           => array(
-							'recipient'      => array( 'type' => 'string' ),
-							'from_name'      => array( 'type' => 'string' ),
-							'from_email'     => array( 'type' => 'string' ),
-							'subject_prefix' => array( 'type' => 'string' ),
-							'html_email'     => array(
+							'recipient'         => array( 'type' => 'string' ),
+							'from_name'         => array( 'type' => 'string' ),
+							'from_email'        => array( 'type' => 'string' ),
+							'subject_prefix'    => array( 'type' => 'string' ),
+							'html_email'        => array(
 								'type' => 'string',
 								'enum' => array( '0', '1' ),
 							),
+							'autoreply_enable'  => array(
+								'type' => 'string',
+								'enum' => array( '0', '1' ),
+							),
+							'autoreply_subject' => array( 'type' => 'string' ),
+							'autoreply_body'    => array( 'type' => 'string' ),
 						),
 						'additionalProperties' => false,
 					),
@@ -282,6 +298,52 @@ class Settings {
 				'description' => __( 'On by default so line breaks survive transports that force HTML or open-tracking (e.g. Postmark). Uncheck to send the notification as plain text instead.', 'fivetwofive-contact-form' ),
 			)
 		);
+
+		add_settings_section(
+			self::SECTION_AUTOREPLY,
+			__( 'Auto-reply', 'fivetwofive-contact-form' ),
+			array( $this, 'section_autoreply' ),
+			self::PAGE_SLUG
+		);
+
+		add_settings_field(
+			'autoreply_enable',
+			__( 'Auto-reply', 'fivetwofive-contact-form' ),
+			array( $this, 'field_checkbox' ),
+			self::PAGE_SLUG,
+			self::SECTION_AUTOREPLY,
+			array(
+				'id'          => 'autoreply_enable',
+				'label'       => __( 'Send a confirmation email to the visitor', 'fivetwofive-contact-form' ),
+				'description' => __( 'Off by default. Enable only when an authenticated transport (e.g. Postmark) is configured — an unauthenticated confirmation to an external inbox will be spam-filtered.', 'fivetwofive-contact-form' ),
+			)
+		);
+
+		add_settings_field(
+			'autoreply_subject',
+			__( 'Auto-reply subject', 'fivetwofive-contact-form' ),
+			array( $this, 'field_input' ),
+			self::PAGE_SLUG,
+			self::SECTION_AUTOREPLY,
+			array(
+				'id'          => 'autoreply_subject',
+				'type'        => 'text',
+				'placeholder' => __( 'Thanks for your message', 'fivetwofive-contact-form' ),
+				'description' => __( 'Subject line of the confirmation. Leave blank for the default.', 'fivetwofive-contact-form' ),
+			)
+		);
+
+		add_settings_field(
+			'autoreply_body',
+			__( 'Auto-reply message', 'fivetwofive-contact-form' ),
+			array( $this, 'field_textarea' ),
+			self::PAGE_SLUG,
+			self::SECTION_AUTOREPLY,
+			array(
+				'id'          => 'autoreply_body',
+				'description' => __( 'Body of the confirmation. Leave blank for the default. Placeholders: {name} (the visitor) and {site_name}.', 'fivetwofive-contact-form' ),
+			)
+		);
 	}
 
 	/**
@@ -297,6 +359,18 @@ class Settings {
 				esc_html__( 'Use the shortcode %s to display the contact form on a page or post. The settings below control where submissions are sent and how the notification email is addressed and formatted.', 'fivetwofive-contact-form' ),
 				'<code>[' . esc_html( Shortcode::SHORTCODE ) . ']</code>'
 			)
+		);
+	}
+
+	/**
+	 * Auto-reply section description.
+	 *
+	 * @since 1.2.0
+	 */
+	public function section_autoreply(): void {
+		printf(
+			'<p>%s</p>',
+			esc_html__( 'Optionally send the visitor a branded confirmation after they submit. It goes to an external inbox, so enable it only with an authenticated transport (e.g. Postmark) — otherwise leave it off.', 'fivetwofive-contact-form' )
 		);
 	}
 
@@ -340,6 +414,18 @@ class Settings {
 
 		if ( isset( $input['html_email'] ) ) {
 			$clean['html_email'] = empty( $input['html_email'] ) ? '0' : '1';
+		}
+
+		if ( isset( $input['autoreply_enable'] ) ) {
+			$clean['autoreply_enable'] = empty( $input['autoreply_enable'] ) ? '0' : '1';
+		}
+
+		if ( isset( $input['autoreply_subject'] ) ) {
+			$clean['autoreply_subject'] = sanitize_text_field( (string) $input['autoreply_subject'] );
+		}
+
+		if ( isset( $input['autoreply_body'] ) ) {
+			$clean['autoreply_body'] = sanitize_textarea_field( (string) $input['autoreply_body'] );
 		}
 
 		// Drop invalid emails rather than storing them.
@@ -394,6 +480,32 @@ class Settings {
 			esc_attr( $id ),
 			esc_attr( $value ),
 			esc_attr( isset( $args['placeholder'] ) ? (string) $args['placeholder'] : '' )
+		);
+
+		if ( ! empty( $args['description'] ) ) {
+			printf( '<p class="description">%s</p>', esc_html( (string) $args['description'] ) );
+		}
+	}
+
+	/**
+	 * Render a multi-line textarea field.
+	 *
+	 * @since 1.2.0
+	 * @param array $args { id, placeholder, description }.
+	 */
+	public function field_textarea( array $args ): void {
+		$options = get_option( self::OPTION, self::defaults() );
+
+		$id    = isset( $args['id'] ) ? (string) $args['id'] : '';
+		$value = isset( $options[ $id ] ) ? (string) $options[ $id ] : '';
+
+		printf(
+			'<textarea id="%1$s" name="%2$s[%3$s]" rows="6" class="large-text" placeholder="%4$s">%5$s</textarea>',
+			esc_attr( self::OPTION . '_' . $id ),
+			esc_attr( self::OPTION ),
+			esc_attr( $id ),
+			esc_attr( isset( $args['placeholder'] ) ? (string) $args['placeholder'] : '' ),
+			esc_textarea( $value )
 		);
 
 		if ( ! empty( $args['description'] ) ) {

--- a/wp-content/plugins/fivetwofive-contact-form/src/Form/Handler.php
+++ b/wp-content/plugins/fivetwofive-contact-form/src/Form/Handler.php
@@ -13,6 +13,7 @@
 
 namespace FiveTwoFive\FiveTwoFive_Contact_Form\Form;
 
+use FiveTwoFive\FiveTwoFive_Contact_Form\Admin\Settings;
 use FiveTwoFive\FiveTwoFive_Contact_Form\Mailer\Mailer;
 use FiveTwoFive\FiveTwoFive_Contact_Form\PostType\Submission;
 
@@ -161,7 +162,36 @@ class Handler {
 		$sent = $this->mailer->send( $fields );
 		$this->submission->set_email_status( $id, $sent );
 
+		// 6. Optionally send the visitor a confirmation. Opt-in (off unless the
+		// owner has a real transport configured), and fire-and-forget: its
+		// outcome must not change the stored lead or the visitor's response.
+		if ( $this->autoreply_enabled() ) {
+			$this->mailer->send_autoreply( $fields );
+		}
+
 		return $this->success( $id );
+	}
+
+	/**
+	 * Whether to send the visitor auto-reply.
+	 *
+	 * Off unless enabled in settings — an unauthenticated confirmation to an
+	 * external mailbox would spam-fold. Filterable so a site can additionally
+	 * gate it on its own transport check.
+	 *
+	 * @since  1.2.0
+	 * @return bool
+	 */
+	private function autoreply_enabled(): bool {
+		$enabled = '1' === Settings::get( 'autoreply_enable' );
+
+		/**
+		 * Filter whether the visitor auto-reply is sent after a submission.
+		 *
+		 * @since 1.2.0
+		 * @param bool $enabled Whether the auto-reply will be sent.
+		 */
+		return (bool) apply_filters( 'fivetwofive_contact_form_send_autoreply', $enabled );
 	}
 
 	/**

--- a/wp-content/plugins/fivetwofive-contact-form/src/Mailer/Mailer.php
+++ b/wp-content/plugins/fivetwofive-contact-form/src/Mailer/Mailer.php
@@ -136,25 +136,130 @@ class Mailer {
 				: sprintf( 'Reply-To: %s', $email );
 		}
 
-		// Optional From identity. Unset by default so the transport (e.g. a
-		// verified Postmark domain) supplies it; a transport with "force from"
-		// may override this regardless.
-		$from_email = Settings::get( 'from_email' );
-		if ( '' !== $from_email && is_email( $from_email ) ) {
-			$from_name = Settings::get( 'from_name' );
-			$headers[] = '' !== $from_name
-				? sprintf( 'From: %s <%s>', $from_name, $from_email )
-				: sprintf( 'From: %s', $from_email );
+		// Optional From identity (see from_header()).
+		$from = $this->from_header();
+		if ( '' !== $from ) {
+			$headers[] = $from;
 		}
 
-		// Send as HTML when enabled. Escaping the assembled (visitor-supplied)
-		// body and converting newlines keeps it safe and preserves line breaks
-		// under transports that force an HTML body.
+		list( $body, $headers ) = $this->apply_format( $body, $headers );
+
+		return (bool) wp_mail( $to, $mail_subject, $body, $headers );
+	}
+
+	/**
+	 * Send the visitor a branded confirmation (auto-reply) after a successful
+	 * submission.
+	 *
+	 * The caller gates this on the `autoreply_enable` setting, so it only fires
+	 * once the site owner has confirmed a real (authenticated) transport is in
+	 * place — an unauthenticated confirmation to an external consumer mailbox
+	 * would spam-fold and hurt sender reputation. From identity and HTML
+	 * formatting follow the same settings as the admin notification; Reply-To is
+	 * the site inbox so the visitor's reply reaches the owner.
+	 *
+	 * @since  1.2.0
+	 * @param  array $data Keys: name, email (others are unused here).
+	 * @return bool Whether wp_mail() accepted the message.
+	 */
+	public function send_autoreply( array $data ): bool {
+		$to = sanitize_email( $data['email'] ?? '' );
+
+		if ( '' === $to || ! is_email( $to ) ) {
+			return false;
+		}
+
+		$name = sanitize_text_field( $data['name'] ?? '' );
+
+		// {name} falls back to a neutral greeting; {site_name} is the blog name
+		// (entity-decoded so "Jane &amp; Co" reads naturally before esc_html()).
+		$replacements = array(
+			'{name}'      => '' !== $name ? $name : __( 'there', 'fivetwofive-contact-form' ),
+			'{site_name}' => wp_specialchars_decode( (string) get_bloginfo( 'name' ), ENT_QUOTES ),
+		);
+
+		$subject = trim( (string) Settings::get( 'autoreply_subject' ) );
+		if ( '' === $subject ) {
+			$subject = __( 'Thanks for your message', 'fivetwofive-contact-form' );
+		}
+		$subject = strtr( $subject, $replacements );
+
+		$body = (string) Settings::get( 'autoreply_body' );
+		if ( '' === trim( $body ) ) {
+			$body = self::default_autoreply_body();
+		}
+		$body = strtr( $body, $replacements );
+
+		// Reply-To the site inbox so the visitor's reply reaches the owner.
+		$headers  = array();
+		$reply_to = sanitize_email( $this->recipient() );
+		if ( '' !== $reply_to && is_email( $reply_to ) ) {
+			$headers[] = sprintf( 'Reply-To: %s', $reply_to );
+		}
+
+		$from = $this->from_header();
+		if ( '' !== $from ) {
+			$headers[] = $from;
+		}
+
+		list( $body, $headers ) = $this->apply_format( $body, $headers );
+
+		return (bool) wp_mail( $to, $subject, $body, $headers );
+	}
+
+	/**
+	 * The optional "From" header, built from settings.
+	 *
+	 * Left empty by default so the transport (e.g. a verified Postmark domain)
+	 * supplies the From; a transport with "force from" may override it anyway.
+	 *
+	 * @since  1.2.0
+	 * @return string A `From: …` header line, or '' when no valid from_email.
+	 */
+	private function from_header(): string {
+		$from_email = Settings::get( 'from_email' );
+
+		if ( '' === $from_email || ! is_email( $from_email ) ) {
+			return '';
+		}
+
+		$from_name = Settings::get( 'from_name' );
+
+		return '' !== $from_name
+			? sprintf( 'From: %s <%s>', $from_name, $from_email )
+			: sprintf( 'From: %s', $from_email );
+	}
+
+	/**
+	 * Apply HTML formatting when the html_email setting is on: set the content
+	 * type and escape + <br>-convert the (untrusted) body. A no-op otherwise.
+	 *
+	 * @since  1.2.0
+	 * @param  string $body    Assembled plain-text body.
+	 * @param  array  $headers Headers accumulated so far.
+	 * @return array{0:string,1:array} The [ body, headers ] for wp_mail().
+	 */
+	private function apply_format( string $body, array $headers ): array {
 		if ( '1' === Settings::get( 'html_email' ) ) {
 			$headers[] = 'Content-Type: text/html; charset=UTF-8';
 			$body      = nl2br( esc_html( $body ) );
 		}
 
-		return (bool) wp_mail( $to, $mail_subject, $body, $headers );
+		return array( $body, $headers );
+	}
+
+	/**
+	 * The built-in auto-reply body, used when the setting is left blank.
+	 *
+	 * Supports the {name} and {site_name} placeholders (see send_autoreply()).
+	 *
+	 * @since  1.2.0
+	 * @return string
+	 */
+	private static function default_autoreply_body(): string {
+		return __(
+			"Hi {name},\n\nThanks for getting in touch. I've received your message and will get back to you as soon as I can.\n\n— {site_name}",
+			'fivetwofive-contact-form'
+		);
 	}
 }


### PR DESCRIPTION
## Summary

- Adds an **opt-in visitor auto-reply**: after a successful submission the plugin can send the submitter a branded "thanks, I'll be in touch" confirmation — the outbound email that most needs deliverability (it goes to an external consumer inbox).
- New **"Auto-reply" settings section**: an enable toggle plus a configurable subject and body, with `{name}` and `{site_name}` placeholders. HTML follows the existing `html_email` setting.
- Sent To the visitor with **Reply-To the site's notification recipient**, so a reply reaches the owner; From is left to the transport (verified Postmark sender) unless the From setting is set.
- Ships as **v1.2.0**. No theme assets touched.

## Decisions baked in

- **Off by default (the safety gate).** The issue requires "no auto-reply when only `wp_mail()` is available." Rather than sniff for a specific transport (brittle, provider-specific), the enable toggle is the provider-agnostic gate — the owner turns it on once an authenticated transport (Postmark) is in place. Production will need the box ticked, same pattern as the `html_email` default note.
- **No hard dependency on #116.** The issue said "depends on authenticated transport," but we established this session that production already authenticates via the Postmark plugin — so the auto-reply rides the existing transport and #116 (bring-transport-in-house) is not a blocker. The opt-in toggle replaces the "wait for #116" gating.
- **Fire-and-forget in the Handler.** The auto-reply is sent after the lead is stored and the admin notified; its result is ignored so a failed confirmation never affects the stored lead or the visitor's on-page response. Delivery-status tracking is intentionally left to #118.
- **Auto-reply omits the admin `subject_prefix`.** That `[Contact]` prefix is for the owner's inbox, not the visitor's.
- **Also filterable** via `fivetwofive_contact_form_send_autoreply` (bool) for sites that want to gate on their own transport check.
- **Refactor:** the shared From-header and HTML-formatting logic moved out of `send()` into `from_header()`/`apply_format()`, reused by both mails (no behavior change to the admin notification — verified).

## Test plan

- [x] `php -l` clean on all changed PHP; `phpcbf` found nothing; `phpcs --standard=phpcs.xml.dist` — 0 violations
- [x] Runtime on LocalWP (`jabaltorres.local`), mail **captured via `wp_mail` filter + short-circuited with `pre_wp_mail` so nothing is actually sent**:
  - `send_autoreply()` → To = visitor, subject = default, body personalized (`{name}`/`{site_name}` substituted, none left over), `Reply-To: info@jabaltorres.com`, `Content-Type: text/html` (per `html_email`), no `From` (Postmark supplies it)
  - Invalid/empty visitor email → returns `false`, no send attempted
  - Refactored `send()` (admin notification) still composes correctly: To = recipient, Reply-To = visitor
  - Gating: `autoreply_enable` default = `"0"`; `field_textarea` + `section_autoreply` present
- [x] `.pot` regenerated (`wp i18n make-pot`) — new strings captured, Project-Id-Version 1.2.0
- [x] No SCSS/JS source touched — plugin CSS is hand-written (no build step)
- [ ] Not exercised: a real end-to-end send through Postmark (would transmit a live email); composition verified via capture instead

## Follow-ups

- Closes #117. Part of epic #102.
- Production: tick **Contact Form → Settings → Auto-reply** to enable it (off by default).
- #118 (Postmark hosted templates + delivery status) builds naturally on this; #116 (in-house transport) remains optional since Postmark already authenticates.