### PR TITLE
feat(contact-form): module-contact-form page-builder module (#121)

### DIFF
--- a/wp-content/plugins/fivetwofive-contact-form/fivetwofive-contact-form.php
+++ b/wp-content/plugins/fivetwofive-contact-form/fivetwofive-contact-form.php
@@ -11,7 +11,7 @@
  * Plugin Name:       FiveTwoFive Contact Form
  * Plugin URI:        https://fivetwofive.com/
  * Description:       A lightweight, dependency-light contact form. Stores every submission as a record and sends notifications via wp_mail() with a swappable mail transport.
- * Version:           1.2.0
+ * Version:           1.3.0
  * Requires at least: 5.2
  * Requires PHP:      7.4
  * Author:            FiveTwoFive Creative Team
@@ -27,7 +27,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Current plugin version.
  */
-define( 'FTF_CONTACT_FORM_VERSION', '1.2.0' );
+define( 'FTF_CONTACT_FORM_VERSION', '1.3.0' );
 
 if ( ! defined( 'FTF_CONTACT_FORM_PLUGIN_FILE' ) ) {
 	define( 'FTF_CONTACT_FORM_PLUGIN_FILE', __FILE__ );
@@ -77,3 +77,30 @@ function FTF_Contact_Form() { // phpcs:ignore WordPress.NamingConventions.ValidF
 }
 
 FTF_Contact_Form();
+
+/**
+ * Render the contact form for direct theme/template placement.
+ *
+ * A first-class alternative to the [fivetwofive_contact_form] shortcode for
+ * page-builder modules and templates: it returns the same markup without
+ * routing it through the_content / wp_kses(), so the form controls are never
+ * stripped (the problem #103 had to work around in the theme's kses ruleset).
+ * The returned markup is the plugin's own escaped output — echo it directly;
+ * do not run it back through wp_kses().
+ *
+ * @since  1.3.0
+ * @param  array $atts Optional. Accepts `title` and `subject`, same as the shortcode.
+ * @return string The form HTML, or '' when the plugin's renderer is unavailable.
+ */
+function fivetwofive_contact_form_render( array $atts = array() ): string {
+	if ( ! class_exists( '\FiveTwoFive\FiveTwoFive_Contact_Form\Frontend\Shortcode' ) ) {
+		return '';
+	}
+
+	$shortcode = new \FiveTwoFive\FiveTwoFive_Contact_Form\Frontend\Shortcode(
+		'fivetwofive_contact_form',
+		defined( 'FTF_CONTACT_FORM_VERSION' ) ? FTF_CONTACT_FORM_VERSION : '1.0.0'
+	);
+
+	return $shortcode->render( $atts );
+}

--- a/wp-content/themes/fivetwofive-theme/CLAUDE.md
+++ b/wp-content/themes/fivetwofive-theme/CLAUDE.md
@@ -133,6 +133,7 @@ add_filter( 'fivetwofive_theme_svg_icons_ui', function( $arr ) {
 | module-accordion | Collapsible sections |
 | module-announcement | Dismissible banners |
 | module-code | Embed code/shortcodes |
+| module-contact-form | Renders the fivetwofive-contact-form plugin's form via `fivetwofive_contact_form_render()` (no kses path) |
 | module-content-and-media | Content + image/video |
 | module-cta | Call-to-action |
 | module-events | Event listing with filters |

--- a/wp-content/themes/fivetwofive-theme/acf-json/group_5c9b8ee97b445.json
+++ b/wp-content/themes/fivetwofive-theme/acf-json/group_5c9b8ee97b445.json
@@ -7882,6 +7882,479 @@
                     ],
                     "min": "",
                     "max": ""
+                },
+                "layout_522ced985a454": {
+                    "key": "layout_522ced985a454",
+                    "name": "module-contact-form",
+                    "label": "Contact Form Module",
+                    "display": "block",
+                    "sub_fields": [
+                        {
+                            "key": "field_d857dfbbe32da",
+                            "label": "Content",
+                            "name": "",
+                            "aria-label": "",
+                            "type": "tab",
+                            "instructions": "",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "placement": "top",
+                            "endpoint": 0,
+                            "selected": 0
+                        },
+                        {
+                            "key": "field_a94a961368074",
+                            "label": "Title",
+                            "name": "title",
+                            "aria-label": "",
+                            "type": "text",
+                            "instructions": "Optional heading shown above the form.",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "50",
+                                "class": "",
+                                "id": ""
+                            },
+                            "default_value": "",
+                            "placeholder": "",
+                            "prepend": "",
+                            "append": "",
+                            "maxlength": ""
+                        },
+                        {
+                            "key": "field_578006ae17f66",
+                            "label": "Subject",
+                            "name": "subject",
+                            "aria-label": "",
+                            "type": "text",
+                            "instructions": "Optional value that pre-fills the form's hidden Subject field.",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "50",
+                                "class": "",
+                                "id": ""
+                            },
+                            "default_value": "",
+                            "placeholder": "",
+                            "prepend": "",
+                            "append": "",
+                            "maxlength": ""
+                        },
+                        {
+                            "key": "field_48f6d17c2cadc",
+                            "label": "Appearance",
+                            "name": "",
+                            "aria-label": "",
+                            "type": "tab",
+                            "instructions": "",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "placement": "top",
+                            "endpoint": 0,
+                            "selected": 0
+                        },
+                        {
+                            "key": "field_2a495dc3394e4",
+                            "label": "Module ID",
+                            "name": "module_id",
+                            "aria-label": "",
+                            "type": "text",
+                            "instructions": "Use a single, or hyphen separated words. <a href=\"https:\/\/developer.mozilla.org\/en-US\/docs\/Web\/HTML\/Global_attributes\/id\" target=\"_blank\">Mozilla documentation<\/a>",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "50",
+                                "class": "",
+                                "id": ""
+                            },
+                            "default_value": "",
+                            "placeholder": "",
+                            "prepend": "",
+                            "append": "",
+                            "maxlength": ""
+                        },
+                        {
+                            "key": "field_211c964e9ca66",
+                            "label": "Module Classes",
+                            "name": "module_classes",
+                            "aria-label": "",
+                            "type": "text",
+                            "instructions": "To add multiple classes just separate with comma. e.g. first-class,second-class",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "50",
+                                "class": "",
+                                "id": ""
+                            },
+                            "default_value": "",
+                            "placeholder": "",
+                            "prepend": "",
+                            "append": "",
+                            "maxlength": ""
+                        },
+                        {
+                            "key": "field_cff589e60d50f",
+                            "label": "Top Spacing",
+                            "name": "spacing_top",
+                            "aria-label": "",
+                            "type": "button_group",
+                            "instructions": "",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "50",
+                                "class": "",
+                                "id": ""
+                            },
+                            "choices": {
+                                "none": "None",
+                                "small": "Small",
+                                "medium": "Medium",
+                                "large": "Large"
+                            },
+                            "default_value": "medium",
+                            "return_format": "value",
+                            "allow_null": 0,
+                            "layout": "horizontal"
+                        },
+                        {
+                            "key": "field_3e5b1a6a58584",
+                            "label": "Bottom Spacing",
+                            "name": "spacing_bottom",
+                            "aria-label": "",
+                            "type": "button_group",
+                            "instructions": "",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "50",
+                                "class": "",
+                                "id": ""
+                            },
+                            "choices": {
+                                "none": "None",
+                                "small": "Small",
+                                "medium": "Medium",
+                                "large": "Large"
+                            },
+                            "default_value": "medium",
+                            "return_format": "value",
+                            "allow_null": 0,
+                            "layout": "horizontal"
+                        },
+                        {
+                            "key": "field_e542916a4debb",
+                            "label": "Background",
+                            "name": "background_toggle",
+                            "aria-label": "",
+                            "type": "true_false",
+                            "instructions": "",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "50",
+                                "class": "",
+                                "id": ""
+                            },
+                            "message": "",
+                            "default_value": 0,
+                            "ui": 1,
+                            "ui_on_text": "Image",
+                            "ui_off_text": "Color"
+                        },
+                        {
+                            "key": "field_220e5c80110d9",
+                            "label": "Background Image",
+                            "name": "background_image",
+                            "aria-label": "",
+                            "type": "image",
+                            "instructions": "",
+                            "required": 0,
+                            "conditional_logic": [
+                                [
+                                    {
+                                        "field": "field_e542916a4debb",
+                                        "operator": "==",
+                                        "value": "1"
+                                    }
+                                ]
+                            ],
+                            "wrapper": {
+                                "width": "50",
+                                "class": "",
+                                "id": ""
+                            },
+                            "return_format": "id",
+                            "preview_size": "medium",
+                            "library": "all",
+                            "min_width": "",
+                            "min_height": "",
+                            "min_size": "",
+                            "max_width": "",
+                            "max_height": "",
+                            "max_size": "",
+                            "mime_types": ""
+                        },
+                        {
+                            "key": "field_e98df94b4212a",
+                            "label": "Background Color",
+                            "name": "background_color",
+                            "aria-label": "",
+                            "type": "color_picker",
+                            "instructions": "",
+                            "required": 0,
+                            "conditional_logic": [
+                                [
+                                    {
+                                        "field": "field_e542916a4debb",
+                                        "operator": "!=",
+                                        "value": "1"
+                                    }
+                                ]
+                            ],
+                            "wrapper": {
+                                "width": "50",
+                                "class": "",
+                                "id": ""
+                            },
+                            "default_value": "",
+                            "enable_opacity": false,
+                            "return_format": "string"
+                        },
+                        {
+                            "key": "field_47899ad24af0f",
+                            "label": "Animation",
+                            "name": "",
+                            "aria-label": "",
+                            "type": "tab",
+                            "instructions": "",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "placement": "top",
+                            "endpoint": 0,
+                            "selected": 0
+                        },
+                        {
+                            "key": "field_19c76c3bc1f78",
+                            "label": "Desktop",
+                            "name": "animation_desktop",
+                            "aria-label": "",
+                            "type": "true_false",
+                            "instructions": "enables\/disables animations on desktop browsers.",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "message": "",
+                            "default_value": 0,
+                            "ui": 1,
+                            "ui_on_text": "",
+                            "ui_off_text": ""
+                        },
+                        {
+                            "key": "field_6abdac2bad2f5",
+                            "label": "Mobile",
+                            "name": "animation_mobile",
+                            "aria-label": "",
+                            "type": "true_false",
+                            "instructions": "enables\/disables animations on mobile browsers.",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "message": "",
+                            "default_value": 0,
+                            "ui": 1,
+                            "ui_on_text": "",
+                            "ui_off_text": ""
+                        },
+                        {
+                            "key": "field_07e58008a09c3",
+                            "label": "Reset",
+                            "name": "animation_reset",
+                            "aria-label": "",
+                            "type": "true_false",
+                            "instructions": "",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "message": "",
+                            "default_value": 0,
+                            "ui": 1,
+                            "ui_on_text": "",
+                            "ui_off_text": ""
+                        },
+                        {
+                            "key": "field_cd8f6d17c2cf6",
+                            "label": "Delay",
+                            "name": "animation_delay",
+                            "aria-label": "",
+                            "type": "number",
+                            "instructions": "Delay is the time before reveal animations begin. By default, delay will be used for all animations. If reset options is true will never use delay.\r\n\r\nThe number passed to delay is a measure of time in milliseconds.",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "default_value": 0,
+                            "placeholder": "",
+                            "prepend": "",
+                            "append": "",
+                            "min": "",
+                            "max": "",
+                            "step": ""
+                        },
+                        {
+                            "key": "field_b465884582661",
+                            "label": "Distance",
+                            "name": "animation_distance",
+                            "aria-label": "",
+                            "type": "number",
+                            "instructions": "Controls how far the module will move when revealed in pixels.",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "default_value": 0,
+                            "placeholder": "",
+                            "prepend": "",
+                            "append": "px",
+                            "min": "",
+                            "max": "",
+                            "step": ""
+                        },
+                        {
+                            "key": "field_462fe70ab3f86",
+                            "label": "Duration",
+                            "name": "animation_duration",
+                            "aria-label": "",
+                            "type": "number",
+                            "instructions": "Controls how long animations take to complete.\r\nAccepted value is a measure of time in milliseconds.",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "default_value": 600,
+                            "placeholder": "",
+                            "prepend": "",
+                            "append": "",
+                            "min": "",
+                            "max": "",
+                            "step": ""
+                        },
+                        {
+                            "key": "field_56516d917f00f",
+                            "label": "Opacity",
+                            "name": "animation_opacity",
+                            "aria-label": "",
+                            "type": "number",
+                            "instructions": "Specifies the opacity the module have prior to being revealed.\r\n\r\nThe number passed to opacity is a range between 0.0 and 1.0. Values outside that range, though valid, will be clamped to the nearest limit.",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "default_value": 0,
+                            "placeholder": "",
+                            "prepend": "",
+                            "append": "",
+                            "min": "0.0",
+                            "max": "1.0",
+                            "step": ""
+                        },
+                        {
+                            "key": "field_b86d4dd050343",
+                            "label": "Origin",
+                            "name": "animation_origin",
+                            "aria-label": "",
+                            "type": "select",
+                            "instructions": "Specifies what direction the module come from when revealed.\r\n\r\nPlease note that You will need a non-zero value assigned to distance for origin to have any visible impact on the module's animation.",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "choices": {
+                                "top": "Top",
+                                "right": "Right",
+                                "bottom": "Bottom",
+                                "left": "Left"
+                            },
+                            "default_value": false,
+                            "allow_null": 0,
+                            "multiple": 0,
+                            "ui": 0,
+                            "return_format": "value",
+                            "ajax": 0,
+                            "placeholder": "",
+                            "create_options": 0,
+                            "save_options": 0
+                        },
+                        {
+                            "key": "field_a9dc24fb2737e",
+                            "label": "Scale",
+                            "name": "animation_scale",
+                            "aria-label": "",
+                            "type": "number",
+                            "instructions": "Specifies the size of elements have prior to being revealed.",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "default_value": 1,
+                            "placeholder": "The number passed to scale is a proportion relative to computed size.",
+                            "prepend": "",
+                            "append": "",
+                            "min": "",
+                            "max": "",
+                            "step": ""
+                        }
+                    ],
+                    "min": "",
+                    "max": ""
                 }
             },
             "button_label": "Add Module",
@@ -7916,5 +8389,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1782453511
+    "modified": 1783746249
 }

--- a/wp-content/themes/fivetwofive-theme/template-parts/modules/module-contact-form.php
+++ b/wp-content/themes/fivetwofive-theme/template-parts/modules/module-contact-form.php
@@ -73,11 +73,13 @@ if ( $module_animation_duration ) {
 }
 
 if ( $module_animation_opacity ) {
-	$module_animation_options['opacity'] = (int) $module_animation_opacity;
+	// Float, not int: the ACF field is 0.0–1.0, so (int) would truncate e.g. 0.5 to 0.
+	$module_animation_options['opacity'] = (float) $module_animation_opacity;
 }
 
 if ( $module_animation_scale ) {
-	$module_animation_options['scale'] = (int) $module_animation_scale;
+	// Float, not int: scale is a proportion (e.g. 0.9), which (int) would truncate to 0.
+	$module_animation_options['scale'] = (float) $module_animation_scale;
 }
 
 if ( $module_animation_desktop || $module_animation_mobile ) {

--- a/wp-content/themes/fivetwofive-theme/template-parts/modules/module-contact-form.php
+++ b/wp-content/themes/fivetwofive-theme/template-parts/modules/module-contact-form.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Template part for displaying the Contact Form module.
+ *
+ * Renders the fivetwofive-contact-form plugin's form by calling its render
+ * function directly, so the form markup is never routed through the_content /
+ * wp_kses() — the canonical placement that avoids the control-stripping #103
+ * had to work around in the kses ruleset. Degrades to nothing when the plugin
+ * is inactive.
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ *
+ * @package FiveTwoFive_Theme
+ */
+
+$module_title      = get_sub_field( 'title' );
+$module_subject    = get_sub_field( 'subject' );
+$background_toggle = get_sub_field( 'background_toggle' );
+$background_color  = get_sub_field( 'background_color' );
+$background_image  = get_sub_field( 'background_image' );
+$module_classes    = '';
+$background        = '';
+
+if ( get_sub_field( 'module_classes' ) ) {
+	$module_classes = implode( ' ', explode( ',', get_sub_field( 'module_classes' ) ) );
+}
+
+// Append responsive Top/Bottom spacing classes from the Appearance tab (issue #62).
+$module_classes = trim( $module_classes . ' ' . fivetwofive_theme_get_module_spacing_classes() );
+
+if ( $background_toggle ) {
+	if ( $background_image ) {
+		$background = "url('" . wp_get_attachment_image_url( $background_image, 'large' ) . "') center center no-repeat";
+	}
+} elseif ( $background_color ) {
+	$background = $background_color;
+}
+
+// Animations.
+$module_id                 = uniqid( 'ftf-module-contact-form' );
+$module_animation_desktop  = get_sub_field( 'animation_desktop' );
+$module_animation_mobile   = get_sub_field( 'animation_mobile' );
+$module_animation_reset    = get_sub_field( 'animation_reset' );
+$module_animation_delay    = get_sub_field( 'animation_delay' );
+$module_animation_distance = get_sub_field( 'animation_distance' );
+$module_animation_duration = get_sub_field( 'animation_duration' );
+$module_animation_opacity  = get_sub_field( 'animation_opacity' );
+$module_animation_origin   = get_sub_field( 'animation_origin' );
+$module_animation_scale    = get_sub_field( 'animation_scale' );
+$module_id_field           = get_sub_field( 'module_id' );
+
+if ( $module_id_field ) {
+	$module_id = $module_id_field;
+}
+
+$module_animation_options = array(
+	'reset'   => $module_animation_reset,
+	'origin'  => $module_animation_origin,
+	'desktop' => $module_animation_desktop,
+	'mobile'  => $module_animation_mobile,
+);
+
+if ( $module_animation_delay ) {
+	$module_animation_options['delay'] = $module_animation_delay;
+}
+
+if ( $module_animation_distance ) {
+	$module_animation_options['distance'] = $module_animation_distance . 'px';
+}
+
+if ( $module_animation_duration ) {
+	$module_animation_options['duration'] = (int) $module_animation_duration;
+}
+
+if ( $module_animation_opacity ) {
+	$module_animation_options['opacity'] = (int) $module_animation_opacity;
+}
+
+if ( $module_animation_scale ) {
+	$module_animation_options['scale'] = (int) $module_animation_scale;
+}
+
+if ( $module_animation_desktop || $module_animation_mobile ) {
+	$module_classes .= ' ftf-module-hidden';
+}
+
+?>
+<section id="<?php echo esc_attr( $module_id ); ?>" data-animation="<?php echo esc_attr( wp_json_encode( $module_animation_options ) ); ?>" class="ftf-module ftf-module-contact-form <?php echo esc_attr( $module_classes ); ?>" style="background:<?php echo esc_attr( $background ); ?>;background-size:cover;">
+	<div class="container">
+		<div class="row">
+			<div class="col-12 col-lg-8 offset-lg-2">
+				<?php
+				if ( function_exists( 'fivetwofive_contact_form_render' ) ) {
+					// Trusted, pre-escaped plugin markup — intentionally NOT run through
+					// wp_kses(): rendering the form directly (not via a shortcode inside
+					// WYSIWYG content) is exactly what keeps the form controls intact (#121/#103).
+					echo fivetwofive_contact_form_render( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						array(
+							'title'   => (string) $module_title,
+							'subject' => (string) $module_subject,
+						)
+					);
+				}
+				?>
+			</div>
+		</div>
+	</div>
+</section>


### PR DESCRIPTION
## Summary

- Adds a first-class **`module-contact-form`** ACF flexible-content module so the contact form can be placed from the page builder — the canonical placement.
- It renders the form by calling a new plugin function **`fivetwofive_contact_form_render()`** directly, so the markup never routes through `the_content` / `wp_kses()`. This is the placement that structurally avoids the form-control stripping #103 had to work around in `fivetwofive_kses_extended_ruleset()`.
- Spans two first-party components: the **plugin** (new render API, bumped to 1.3.0) and the **parent theme** (module template + ACF layout + docs). No SCSS/JS change.

## Decisions baked in

- **New public `fivetwofive_contact_form_render( $atts )` instead of `do_shortcode()` in the template.** The issue asks for the render function specifically; a clean function is the canonical theme↔plugin interface, accepts `title`/`subject`, and returns the plugin's own escaped markup. The module `echo`s it directly with a scoped `phpcs:ignore` — running trusted plugin output back through kses is exactly what we're avoiding.
- **Full-parity ACF layout (your call).** Cloned `module-code`'s complete scaffolding (Appearance: spacing, custom classes/ID, background image/color; Animations tab) and swapped its `code` field for optional `title` + `subject`. The layout was added by **cloning + deterministically re-keying** every field/layout key across the subtree (so the internal `background_toggle` conditional logic stays valid) — verified byte-faithful, globally key-unique, and ACF-loadable.
- **Parent theme, not child.** It's a framework-level module (any site on the framework + plugin), matching the issue and the "fix the framework" precedent; the child can still override it.
- **No SCSS partial / no rebuild.** Form styling is the plugin's CSS (enqueued by `render()`); the wrapper uses the generic `.ftf-module` styles. Consistent with `module-code` / `module-content-and-media`, which also have no partial.
- **Parent theme version left at 1.0.1** — recent module features (e.g. works-module search) didn't bump it; theme version is bumped deliberately, not per-feature.

## Test plan

- [x] `php -l` clean (plugin main + module template); `phpcs` clean on both (plugin standard on the main file; WordPress-standard escaping/indent sniffs on the template)
- [x] ACF JSON: round-trip proven **byte-identical** to ACF's format before editing; final diff is +the new layout and the single `modified` line only; JSON valid; **no duplicate field/layout keys** globally
- [x] `acf_get_field_group()` on LocalWP sees `module-contact-form` ("Contact Form Module") with `title:text, subject:text`, 21 subs
- [x] `fivetwofive_contact_form_render(['title'=>…,'subject'=>…])` returns full form HTML — `<form>`, title heading, prefilled subject, honeypot inline style, nonce
- [x] **End-to-end on LocalWP**: created a throwaway draft page with the layout, rendered it through the real `template-module.php` dispatch → `module-contact-form.php` loaded, form rendered, `title`/`subject` sub-fields flowed through, correct `.ftf-module ftf-module-contact-form` wrapper + grid; **temp page hard-deleted and confirmed gone**
- [x] Plugin inactive → `function_exists()` guard makes the module render nothing (graceful)

## Follow-ups

- Closes #121. Part of epic #102.
- On deploy, ACF may show a cosmetic "Sync available" notice for the field group; the module renders straight from local JSON regardless (verified — the E2E test needed no sync).
- With the canonical module in place, the `<form>`/`<input>` entries added to the kses ruleset in #103 could eventually be revisited if no other module relies on inline form shortcodes — not done here (out of scope, needs its own audit).