### PR TITLE
feat(contact-form): per-IP submission rate limiting (#100)

### DIFF
--- a/wp-content/plugins/fivetwofive-contact-form/fivetwofive-contact-form.php
+++ b/wp-content/plugins/fivetwofive-contact-form/fivetwofive-contact-form.php
@@ -11,7 +11,7 @@
  * Plugin Name:       FiveTwoFive Contact Form
  * Plugin URI:        https://fivetwofive.com/
  * Description:       A lightweight, dependency-light contact form. Stores every submission as a record and sends notifications via wp_mail() with a swappable mail transport.
- * Version:           1.3.0
+ * Version:           1.4.0
  * Requires at least: 5.2
  * Requires PHP:      7.4
  * Author:            FiveTwoFive Creative Team
@@ -27,7 +27,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Current plugin version.
  */
-define( 'FTF_CONTACT_FORM_VERSION', '1.3.0' );
+define( 'FTF_CONTACT_FORM_VERSION', '1.4.0' );
 
 if ( ! defined( 'FTF_CONTACT_FORM_PLUGIN_FILE' ) ) {
 	define( 'FTF_CONTACT_FORM_PLUGIN_FILE', __FILE__ );

--- a/wp-content/plugins/fivetwofive-contact-form/languages/fivetwofive-contact-form.pot
+++ b/wp-content/plugins/fivetwofive-contact-form/languages/fivetwofive-contact-form.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-11T21:10:20+00:00\n"
+"POT-Creation-Date: 2026-07-11T21:31:19+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: fivetwofive-contact-form\n"
@@ -82,111 +82,125 @@ msgstr ""
 msgid "Send Message"
 msgstr ""
 
-#: src/Admin/Settings.php:160
+#: src/Admin/Settings.php:167
 msgid "Contact Form Settings"
 msgstr ""
 
-#: src/Admin/Settings.php:161
+#: src/Admin/Settings.php:168
 msgid "Settings"
 msgstr ""
 
-#: src/Admin/Settings.php:230
+#: src/Admin/Settings.php:237
 msgid "Notifications"
 msgstr ""
 
-#: src/Admin/Settings.php:237
+#: src/Admin/Settings.php:244
 msgid "Notification recipient"
 msgstr ""
 
-#: src/Admin/Settings.php:245
+#: src/Admin/Settings.php:252
 msgid "Where submission notifications are sent. Leave blank to use the site admin email."
 msgstr ""
 
-#: src/Admin/Settings.php:251
+#: src/Admin/Settings.php:258
 msgid "Sender name"
 msgstr ""
 
-#: src/Admin/Settings.php:258
+#: src/Admin/Settings.php:265
 msgid "Optional \"From\" name on the notification."
 msgstr ""
 
-#: src/Admin/Settings.php:264
+#: src/Admin/Settings.php:271
 msgid "Sender email (From)"
 msgstr ""
 
-#: src/Admin/Settings.php:271
+#: src/Admin/Settings.php:278
 msgid "Optional \"From\" address. Leave blank to let the mail transport set it. A transport like Postmark with \"force from\" enabled may override this."
 msgstr ""
 
-#: src/Admin/Settings.php:277
+#: src/Admin/Settings.php:284
 msgid "Subject prefix"
 msgstr ""
 
-#: src/Admin/Settings.php:285
+#: src/Admin/Settings.php:292
 msgid "Prepended to the notification subject line."
 msgstr ""
 
-#: src/Admin/Settings.php:291
+#: src/Admin/Settings.php:298
 msgid "Send as HTML"
 msgstr ""
 
-#: src/Admin/Settings.php:297
+#: src/Admin/Settings.php:304
 msgid "Send the notification as HTML"
 msgstr ""
 
-#: src/Admin/Settings.php:298
+#: src/Admin/Settings.php:305
 msgid "On by default so line breaks survive transports that force HTML or open-tracking (e.g. Postmark). Uncheck to send the notification as plain text instead."
 msgstr ""
 
-#: src/Admin/Settings.php:304
 #: src/Admin/Settings.php:311
+#: src/Admin/Settings.php:318
 msgid "Auto-reply"
 msgstr ""
 
-#: src/Admin/Settings.php:317
+#: src/Admin/Settings.php:324
 msgid "Send a confirmation email to the visitor"
 msgstr ""
 
-#: src/Admin/Settings.php:318
+#: src/Admin/Settings.php:325
 msgid "Off by default. Enable only when an authenticated transport (e.g. Postmark) is configured — an unauthenticated confirmation to an external inbox will be spam-filtered."
 msgstr ""
 
-#: src/Admin/Settings.php:324
+#: src/Admin/Settings.php:331
 msgid "Auto-reply subject"
 msgstr ""
 
-#: src/Admin/Settings.php:331
+#: src/Admin/Settings.php:338
 #: src/Mailer/Mailer.php:183
 msgid "Thanks for your message"
 msgstr ""
 
-#: src/Admin/Settings.php:332
+#: src/Admin/Settings.php:339
 msgid "Subject line of the confirmation. Leave blank for the default."
 msgstr ""
 
-#: src/Admin/Settings.php:338
+#: src/Admin/Settings.php:345
 msgid "Auto-reply message"
 msgstr ""
 
-#: src/Admin/Settings.php:344
+#: src/Admin/Settings.php:351
 msgid "Body of the confirmation. Leave blank for the default. Placeholders: {name} (the visitor) and {site_name}."
 msgstr ""
 
+#: src/Admin/Settings.php:360
+msgid "Spam protection"
+msgstr ""
+
 #. translators: %s: the contact form shortcode, wrapped in a <code> tag.
-#: src/Admin/Settings.php:359
+#: src/Admin/Settings.php:376
 #, php-format
 msgid "Use the shortcode %s to display the contact form on a page or post. The settings below control where submissions are sent and how the notification email is addressed and formatted."
 msgstr ""
 
-#: src/Admin/Settings.php:373
+#: src/Admin/Settings.php:390
 msgid "Optionally send the visitor a branded confirmation after they submit. It goes to an external inbox, so enable it only with an authenticated transport (e.g. Postmark) — otherwise leave it off."
 msgstr ""
 
-#: src/Admin/Settings.php:433
+#: src/Admin/Settings.php:402
+msgid "The form is protected by a honeypot, a timing check, and a per-IP rate limit (5 submissions per 10 minutes by default) — no CAPTCHA required."
+msgstr ""
+
+#. translators: 1: the client-IP filter name, 2: the rate-limit filter name, each wrapped in a <code> tag.
+#: src/Admin/Settings.php:405
+#, php-format
+msgid "If this site is served through a CDN or reverse proxy such as Cloudflare, visitors can all appear to come from the CDN itself (a shared IP), which may cause the rate limit to block unrelated people. In that setup a developer should supply the real visitor IP via the %1$s filter, or disable the limit with %2$s."
+msgstr ""
+
+#: src/Admin/Settings.php:468
 msgid "The notification recipient must be a valid email address."
 msgstr ""
 
-#: src/Admin/Settings.php:438
+#: src/Admin/Settings.php:473
 msgid "The sender email must be a valid email address."
 msgstr ""
 

--- a/wp-content/plugins/fivetwofive-contact-form/languages/fivetwofive-contact-form.pot
+++ b/wp-content/plugins/fivetwofive-contact-form/languages/fivetwofive-contact-form.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-11T21:31:19+00:00\n"
+"POT-Creation-Date: 2026-07-11T21:40:07+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: fivetwofive-contact-form\n"
@@ -44,7 +44,7 @@ msgid "Settings saved."
 msgstr ""
 
 #: resources/views/frontend/contact-form.php:35
-#: src/Form/Handler.php:327
+#: src/Form/Handler.php:343
 msgid "Thanks — your message has been sent."
 msgstr ""
 
@@ -82,125 +82,145 @@ msgstr ""
 msgid "Send Message"
 msgstr ""
 
-#: src/Admin/Settings.php:167
+#: src/Admin/Settings.php:169
 msgid "Contact Form Settings"
 msgstr ""
 
-#: src/Admin/Settings.php:168
+#: src/Admin/Settings.php:170
 msgid "Settings"
 msgstr ""
 
-#: src/Admin/Settings.php:237
+#: src/Admin/Settings.php:244
 msgid "Notifications"
 msgstr ""
 
-#: src/Admin/Settings.php:244
+#: src/Admin/Settings.php:251
 msgid "Notification recipient"
 msgstr ""
 
-#: src/Admin/Settings.php:252
+#: src/Admin/Settings.php:259
 msgid "Where submission notifications are sent. Leave blank to use the site admin email."
 msgstr ""
 
-#: src/Admin/Settings.php:258
+#: src/Admin/Settings.php:265
 msgid "Sender name"
 msgstr ""
 
-#: src/Admin/Settings.php:265
+#: src/Admin/Settings.php:272
 msgid "Optional \"From\" name on the notification."
 msgstr ""
 
-#: src/Admin/Settings.php:271
+#: src/Admin/Settings.php:278
 msgid "Sender email (From)"
 msgstr ""
 
-#: src/Admin/Settings.php:278
+#: src/Admin/Settings.php:285
 msgid "Optional \"From\" address. Leave blank to let the mail transport set it. A transport like Postmark with \"force from\" enabled may override this."
 msgstr ""
 
-#: src/Admin/Settings.php:284
+#: src/Admin/Settings.php:291
 msgid "Subject prefix"
 msgstr ""
 
-#: src/Admin/Settings.php:292
+#: src/Admin/Settings.php:299
 msgid "Prepended to the notification subject line."
 msgstr ""
 
-#: src/Admin/Settings.php:298
+#: src/Admin/Settings.php:305
 msgid "Send as HTML"
 msgstr ""
 
-#: src/Admin/Settings.php:304
+#: src/Admin/Settings.php:311
 msgid "Send the notification as HTML"
 msgstr ""
 
-#: src/Admin/Settings.php:305
+#: src/Admin/Settings.php:312
 msgid "On by default so line breaks survive transports that force HTML or open-tracking (e.g. Postmark). Uncheck to send the notification as plain text instead."
 msgstr ""
 
-#: src/Admin/Settings.php:311
 #: src/Admin/Settings.php:318
+#: src/Admin/Settings.php:325
 msgid "Auto-reply"
 msgstr ""
 
-#: src/Admin/Settings.php:324
+#: src/Admin/Settings.php:331
 msgid "Send a confirmation email to the visitor"
 msgstr ""
 
-#: src/Admin/Settings.php:325
+#: src/Admin/Settings.php:332
 msgid "Off by default. Enable only when an authenticated transport (e.g. Postmark) is configured — an unauthenticated confirmation to an external inbox will be spam-filtered."
 msgstr ""
 
-#: src/Admin/Settings.php:331
+#: src/Admin/Settings.php:338
 msgid "Auto-reply subject"
 msgstr ""
 
-#: src/Admin/Settings.php:338
+#: src/Admin/Settings.php:345
 #: src/Mailer/Mailer.php:183
 msgid "Thanks for your message"
 msgstr ""
 
-#: src/Admin/Settings.php:339
+#: src/Admin/Settings.php:346
 msgid "Subject line of the confirmation. Leave blank for the default."
 msgstr ""
 
-#: src/Admin/Settings.php:345
+#: src/Admin/Settings.php:352
 msgid "Auto-reply message"
 msgstr ""
 
-#: src/Admin/Settings.php:351
+#: src/Admin/Settings.php:358
 msgid "Body of the confirmation. Leave blank for the default. Placeholders: {name} (the visitor) and {site_name}."
 msgstr ""
 
-#: src/Admin/Settings.php:360
+#: src/Admin/Settings.php:367
 msgid "Spam protection"
 msgstr ""
 
+#: src/Admin/Settings.php:374
+msgid "Rate limit"
+msgstr ""
+
+#: src/Admin/Settings.php:380
+msgid "Limit how many times one IP can submit"
+msgstr ""
+
+#: src/Admin/Settings.php:381
+msgid "On by default. Turn off if this site sits behind a CDN that shares one IP across visitors (see above) and you cannot supply the real client IP."
+msgstr ""
+
+#: src/Admin/Settings.php:387
+msgid "Max submissions"
+msgstr ""
+
+#: src/Admin/Settings.php:395
+msgid "Submissions allowed from one IP per 10 minutes before further ones are blocked. Default 5."
+msgstr ""
+
 #. translators: %s: the contact form shortcode, wrapped in a <code> tag.
-#: src/Admin/Settings.php:376
+#: src/Admin/Settings.php:410
 #, php-format
 msgid "Use the shortcode %s to display the contact form on a page or post. The settings below control where submissions are sent and how the notification email is addressed and formatted."
 msgstr ""
 
-#: src/Admin/Settings.php:390
+#: src/Admin/Settings.php:424
 msgid "Optionally send the visitor a branded confirmation after they submit. It goes to an external inbox, so enable it only with an authenticated transport (e.g. Postmark) — otherwise leave it off."
 msgstr ""
 
-#: src/Admin/Settings.php:402
-msgid "The form is protected by a honeypot, a timing check, and a per-IP rate limit (5 submissions per 10 minutes by default) — no CAPTCHA required."
+#: src/Admin/Settings.php:436
+msgid "The form is protected by a honeypot, a timing check, and a per-IP rate limit (configured below) — no CAPTCHA required."
 msgstr ""
 
-#. translators: 1: the client-IP filter name, 2: the rate-limit filter name, each wrapped in a <code> tag.
-#: src/Admin/Settings.php:405
+#. translators: %s: the client-IP filter name, wrapped in a <code> tag.
+#: src/Admin/Settings.php:439
 #, php-format
-msgid "If this site is served through a CDN or reverse proxy such as Cloudflare, visitors can all appear to come from the CDN itself (a shared IP), which may cause the rate limit to block unrelated people. In that setup a developer should supply the real visitor IP via the %1$s filter, or disable the limit with %2$s."
+msgid "If this site is served through a CDN or reverse proxy such as Cloudflare, visitors can all appear to come from the CDN itself (a shared IP), which may cause the rate limit to block unrelated people. In that setup a developer should supply the real visitor IP via the %s filter — or simply turn the rate limit off below."
 msgstr ""
 
-#: src/Admin/Settings.php:468
+#: src/Admin/Settings.php:512
 msgid "The notification recipient must be a valid email address."
 msgstr ""
 
-#: src/Admin/Settings.php:473
+#: src/Admin/Settings.php:517
 msgid "The sender email must be a valid email address."
 msgstr ""
 

--- a/wp-content/plugins/fivetwofive-contact-form/languages/fivetwofive-contact-form.pot
+++ b/wp-content/plugins/fivetwofive-contact-form/languages/fivetwofive-contact-form.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: FiveTwoFive Contact Form 1.2.0\n"
+"Project-Id-Version: FiveTwoFive Contact Form 1.4.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/fivetwofive-contact-form\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-11T04:33:07+00:00\n"
+"POT-Creation-Date: 2026-07-11T21:10:20+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: fivetwofive-contact-form\n"
@@ -44,7 +44,7 @@ msgid "Settings saved."
 msgstr ""
 
 #: resources/views/frontend/contact-form.php:35
-#: src/Form/Handler.php:235
+#: src/Form/Handler.php:327
 msgid "Thanks — your message has been sent."
 msgstr ""
 
@@ -198,23 +198,27 @@ msgstr ""
 msgid "That looked a little too quick — please take a moment and send your message again."
 msgstr ""
 
-#: src/Form/Handler.php:120
+#: src/Form/Handler.php:117
+msgid "You have sent several messages recently. Please wait a few minutes before sending another."
+msgstr ""
+
+#: src/Form/Handler.php:131
 msgid "Please enter your name."
 msgstr ""
 
-#: src/Form/Handler.php:124
+#: src/Form/Handler.php:135
 msgid "Please enter a valid email address."
 msgstr ""
 
-#: src/Form/Handler.php:128
+#: src/Form/Handler.php:139
 msgid "Please enter a message."
 msgstr ""
 
-#: src/Form/Handler.php:136
+#: src/Form/Handler.php:147
 msgid "One or more fields are too long."
 msgstr ""
 
-#: src/Form/Handler.php:157
+#: src/Form/Handler.php:168
 msgid "Something went wrong saving your message. Please try again."
 msgstr ""
 

--- a/wp-content/plugins/fivetwofive-contact-form/src/Admin/Settings.php
+++ b/wp-content/plugins/fivetwofive-contact-form/src/Admin/Settings.php
@@ -125,6 +125,8 @@ class Settings {
 			'autoreply_enable'  => '0',
 			'autoreply_subject' => '',
 			'autoreply_body'    => '',
+			'rate_limit_enable' => '1',
+			'rate_limit_max'    => '5',
 		);
 	}
 
@@ -217,6 +219,11 @@ class Settings {
 							),
 							'autoreply_subject' => array( 'type' => 'string' ),
 							'autoreply_body'    => array( 'type' => 'string' ),
+							'rate_limit_enable' => array(
+								'type' => 'string',
+								'enum' => array( '0', '1' ),
+							),
+							'rate_limit_max'    => array( 'type' => 'string' ),
 						),
 						'additionalProperties' => false,
 					),
@@ -352,14 +359,41 @@ class Settings {
 			)
 		);
 
-		// Informational only: the spam defenses store no options (the rate limit
-		// is filter-configurable), so this section is a description with no fields
-		// — a home for the CDN caveat an operator would otherwise never see.
+		// Spam-protection controls: an enable toggle + threshold for the per-IP
+		// rate limit. The section description (section_spam) also carries the CDN
+		// caveat an operator would otherwise never see.
 		add_settings_section(
 			self::SECTION_SPAM,
 			__( 'Spam protection', 'fivetwofive-contact-form' ),
 			array( $this, 'section_spam' ),
 			self::PAGE_SLUG
+		);
+
+		add_settings_field(
+			'rate_limit_enable',
+			__( 'Rate limit', 'fivetwofive-contact-form' ),
+			array( $this, 'field_checkbox' ),
+			self::PAGE_SLUG,
+			self::SECTION_SPAM,
+			array(
+				'id'          => 'rate_limit_enable',
+				'label'       => __( 'Limit how many times one IP can submit', 'fivetwofive-contact-form' ),
+				'description' => __( 'On by default. Turn off if this site sits behind a CDN that shares one IP across visitors (see above) and you cannot supply the real client IP.', 'fivetwofive-contact-form' ),
+			)
+		);
+
+		add_settings_field(
+			'rate_limit_max',
+			__( 'Max submissions', 'fivetwofive-contact-form' ),
+			array( $this, 'field_input' ),
+			self::PAGE_SLUG,
+			self::SECTION_SPAM,
+			array(
+				'id'          => 'rate_limit_max',
+				'type'        => 'number',
+				'placeholder' => '5',
+				'description' => __( 'Submissions allowed from one IP per 10 minutes before further ones are blocked. Default 5.', 'fivetwofive-contact-form' ),
+			)
 		);
 	}
 
@@ -399,12 +433,11 @@ class Settings {
 	public function section_spam(): void {
 		printf(
 			'<p>%s</p><p>%s</p>',
-			esc_html__( 'The form is protected by a honeypot, a timing check, and a per-IP rate limit (5 submissions per 10 minutes by default) — no CAPTCHA required.', 'fivetwofive-contact-form' ),
+			esc_html__( 'The form is protected by a honeypot, a timing check, and a per-IP rate limit (configured below) — no CAPTCHA required.', 'fivetwofive-contact-form' ),
 			sprintf(
-				/* translators: 1: the client-IP filter name, 2: the rate-limit filter name, each wrapped in a <code> tag. */
-				esc_html__( 'If this site is served through a CDN or reverse proxy such as Cloudflare, visitors can all appear to come from the CDN itself (a shared IP), which may cause the rate limit to block unrelated people. In that setup a developer should supply the real visitor IP via the %1$s filter, or disable the limit with %2$s.', 'fivetwofive-contact-form' ),
-				'<code>fivetwofive_contact_form_client_ip</code>',
-				'<code>fivetwofive_contact_form_rate_limit</code>'
+				/* translators: %s: the client-IP filter name, wrapped in a <code> tag. */
+				esc_html__( 'If this site is served through a CDN or reverse proxy such as Cloudflare, visitors can all appear to come from the CDN itself (a shared IP), which may cause the rate limit to block unrelated people. In that setup a developer should supply the real visitor IP via the %s filter — or simply turn the rate limit off below.', 'fivetwofive-contact-form' ),
+				'<code>fivetwofive_contact_form_client_ip</code>'
 			)
 		);
 	}
@@ -461,6 +494,17 @@ class Settings {
 
 		if ( isset( $input['autoreply_body'] ) ) {
 			$clean['autoreply_body'] = sanitize_textarea_field( (string) $input['autoreply_body'] );
+		}
+
+		if ( isset( $input['rate_limit_enable'] ) ) {
+			$clean['rate_limit_enable'] = empty( $input['rate_limit_enable'] ) ? '0' : '1';
+		}
+
+		if ( isset( $input['rate_limit_max'] ) ) {
+			// Keep it at least 1 so an enabled limit always blocks something; a
+			// blank or 0 entry falls back to the default.
+			$max                     = absint( $input['rate_limit_max'] );
+			$clean['rate_limit_max'] = (string) ( $max > 0 ? $max : 5 );
 		}
 
 		// Drop invalid emails rather than storing them.

--- a/wp-content/plugins/fivetwofive-contact-form/src/Admin/Settings.php
+++ b/wp-content/plugins/fivetwofive-contact-form/src/Admin/Settings.php
@@ -62,6 +62,13 @@ class Settings {
 	private const SECTION_AUTOREPLY = 'ftf_contact_form_autoreply';
 
 	/**
+	 * Spam-protection (informational) section id.
+	 *
+	 * @var string
+	 */
+	private const SECTION_SPAM = 'ftf_contact_form_spam';
+
+	/**
 	 * Admin notice group for settings errors. Public so the page view can pass
 	 * it to settings_errors().
 	 *
@@ -344,6 +351,16 @@ class Settings {
 				'description' => __( 'Body of the confirmation. Leave blank for the default. Placeholders: {name} (the visitor) and {site_name}.', 'fivetwofive-contact-form' ),
 			)
 		);
+
+		// Informational only: the spam defenses store no options (the rate limit
+		// is filter-configurable), so this section is a description with no fields
+		// — a home for the CDN caveat an operator would otherwise never see.
+		add_settings_section(
+			self::SECTION_SPAM,
+			__( 'Spam protection', 'fivetwofive-contact-form' ),
+			array( $this, 'section_spam' ),
+			self::PAGE_SLUG
+		);
 	}
 
 	/**
@@ -371,6 +388,24 @@ class Settings {
 		printf(
 			'<p>%s</p>',
 			esc_html__( 'Optionally send the visitor a branded confirmation after they submit. It goes to an external inbox, so enable it only with an authenticated transport (e.g. Postmark) — otherwise leave it off.', 'fivetwofive-contact-form' )
+		);
+	}
+
+	/**
+	 * Spam-protection section description (informational; no fields).
+	 *
+	 * @since 1.4.0
+	 */
+	public function section_spam(): void {
+		printf(
+			'<p>%s</p><p>%s</p>',
+			esc_html__( 'The form is protected by a honeypot, a timing check, and a per-IP rate limit (5 submissions per 10 minutes by default) — no CAPTCHA required.', 'fivetwofive-contact-form' ),
+			sprintf(
+				/* translators: 1: the client-IP filter name, 2: the rate-limit filter name, each wrapped in a <code> tag. */
+				esc_html__( 'If this site is served through a CDN or reverse proxy such as Cloudflare, visitors can all appear to come from the CDN itself (a shared IP), which may cause the rate limit to block unrelated people. In that setup a developer should supply the real visitor IP via the %1$s filter, or disable the limit with %2$s.', 'fivetwofive-contact-form' ),
+				'<code>fivetwofive_contact_form_client_ip</code>',
+				'<code>fivetwofive_contact_form_rate_limit</code>'
+			)
 		);
 	}
 

--- a/wp-content/plugins/fivetwofive-contact-form/src/Admin/Settings.php
+++ b/wp-content/plugins/fivetwofive-contact-form/src/Admin/Settings.php
@@ -539,13 +539,32 @@ class Settings {
 	}
 
 	/**
+	 * Stored options merged over the defaults, for the field renderers.
+	 *
+	 * `get_option()` only returns its default when the row is absent, so an
+	 * option array saved by an earlier version lacks keys added since. Merging
+	 * the defaults under the stored values makes a missing key fall back to its
+	 * default — critical for a default-on toggle like `rate_limit_enable`, which
+	 * would otherwise render unchecked and be saved as '0', silently disabling
+	 * it. Mirrors the merge in sanitize().
+	 *
+	 * @since  1.4.0
+	 * @return array
+	 */
+	private static function stored_options(): array {
+		$stored = get_option( self::OPTION, array() );
+
+		return array_merge( self::defaults(), is_array( $stored ) ? $stored : array() );
+	}
+
+	/**
 	 * Render a text/email input field.
 	 *
 	 * @since 1.1.0
 	 * @param array $args { id, type, placeholder, description }.
 	 */
 	public function field_input( array $args ): void {
-		$options = get_option( self::OPTION, self::defaults() );
+		$options = self::stored_options();
 
 		$id    = isset( $args['id'] ) ? (string) $args['id'] : '';
 		$type  = isset( $args['type'] ) ? (string) $args['type'] : 'text';
@@ -573,7 +592,7 @@ class Settings {
 	 * @param array $args { id, placeholder, description }.
 	 */
 	public function field_textarea( array $args ): void {
-		$options = get_option( self::OPTION, self::defaults() );
+		$options = self::stored_options();
 
 		$id    = isset( $args['id'] ) ? (string) $args['id'] : '';
 		$value = isset( $options[ $id ] ) ? (string) $options[ $id ] : '';
@@ -599,7 +618,7 @@ class Settings {
 	 * @param array $args { id, label, description }.
 	 */
 	public function field_checkbox( array $args ): void {
-		$options = get_option( self::OPTION, self::defaults() );
+		$options = self::stored_options();
 
 		$id      = isset( $args['id'] ) ? (string) $args['id'] : '';
 		$checked = isset( $options[ $id ] ) && '1' === (string) $options[ $id ];

--- a/wp-content/plugins/fivetwofive-contact-form/src/Form/Endpoints.php
+++ b/wp-content/plugins/fivetwofive-contact-form/src/Form/Endpoints.php
@@ -164,6 +164,8 @@ class Endpoints {
 				return 403;
 			case 'invalid':
 				return 422;
+			case 'rate_limited':
+				return 429;
 			case 'store_failed':
 				return 500;
 			default:

--- a/wp-content/plugins/fivetwofive-contact-form/src/Form/Handler.php
+++ b/wp-content/plugins/fivetwofive-contact-form/src/Form/Handler.php
@@ -219,14 +219,30 @@ class Handler {
 	 * @return bool True when the current IP is over its limit.
 	 */
 	private function is_rate_limited(): bool {
+		// Master toggle from the settings page (filterable). Off → no limiting.
+		$enabled = '1' === Settings::get( 'rate_limit_enable' );
+
 		/**
-		 * Filter the maximum submissions allowed per IP per window. Return 0 (or
-		 * less) to disable the rate limit entirely.
+		 * Filter whether the per-IP rate limit is enforced. Defaults to the
+		 * settings-page toggle.
+		 *
+		 * @since 1.4.0
+		 * @param bool $enabled Whether the rate limit is active.
+		 */
+		if ( ! (bool) apply_filters( 'fivetwofive_contact_form_rate_limit_enabled', $enabled ) ) {
+			return false;
+		}
+
+		$configured = (int) Settings::get( 'rate_limit_max' );
+
+		/**
+		 * Filter the maximum submissions allowed per IP per window. Defaults to
+		 * the settings-page value; return 0 (or less) to disable entirely.
 		 *
 		 * @since 1.4.0
 		 * @param int $limit Max submissions per window.
 		 */
-		$limit = (int) apply_filters( 'fivetwofive_contact_form_rate_limit', 5 );
+		$limit = (int) apply_filters( 'fivetwofive_contact_form_rate_limit', $configured > 0 ? $configured : 5 );
 
 		if ( $limit <= 0 ) {
 			return false;

--- a/wp-content/plugins/fivetwofive-contact-form/src/Form/Handler.php
+++ b/wp-content/plugins/fivetwofive-contact-form/src/Form/Handler.php
@@ -262,16 +262,56 @@ class Handler {
 		 */
 		$window = (int) apply_filters( 'fivetwofive_contact_form_rate_window', 10 * MINUTE_IN_SECONDS );
 
-		$key   = 'ftf_cf_rl_' . wp_hash( $ip );
-		$count = (int) get_transient( $key );
+		$key = 'ftf_cf_rl_' . wp_hash( $ip );
 
-		if ( $count >= $limit ) {
-			return true;
+		return $this->record_hit( $key, max( 1, $window ) ) > $limit;
+	}
+
+	/**
+	 * Record one hit against $key and return the running count for its window.
+	 *
+	 * Prefers an atomic object-cache counter when a persistent backend is
+	 * present: `wp_cache_incr` is a single atomic op (e.g. Redis INCR) so
+	 * concurrent requests can't race past the limit, and `wp_cache_add` seeds
+	 * the TTL once so the window runs from the first hit rather than being
+	 * pushed out by every submission. Falls back to a transient that stores the
+	 * window's start timestamp — which keeps the window fixed from the first hit
+	 * — but whose read/modify/write is best-effort under truly-parallel bursts
+	 * (the honeypot + time-trap already backstop that).
+	 *
+	 * @since  1.4.0
+	 * @param  string $key    Per-IP counter key.
+	 * @param  int    $window Window length in seconds (>= 1).
+	 * @return int The hits recorded in the current window, this one included.
+	 */
+	private function record_hit( string $key, int $window ): int {
+		if ( wp_using_ext_object_cache() ) {
+			$group = 'fivetwofive_contact_form_rl';
+			wp_cache_add( $key, 0, $group, $window );
+			$count = wp_cache_incr( $key, 1, $group );
+
+			if ( is_int( $count ) ) {
+				return $count;
+			}
 		}
 
-		set_transient( $key, $count + 1, max( 1, $window ) );
+		$now  = time();
+		$data = get_transient( $key );
 
-		return false;
+		if ( ! is_array( $data ) || ( $now - (int) ( $data['start'] ?? 0 ) ) >= $window ) {
+			$data = array(
+				'start' => $now,
+				'count' => 0,
+			);
+		}
+
+		++$data['count'];
+
+		// TTL tracks the time left in the original window, so repeated hits never
+		// push the expiry out — the window stays anchored to its first hit.
+		set_transient( $key, $data, max( 1, $window - ( $now - (int) $data['start'] ) ) );
+
+		return (int) $data['count'];
 	}
 
 	/**

--- a/wp-content/plugins/fivetwofive-contact-form/src/Form/Handler.php
+++ b/wp-content/plugins/fivetwofive-contact-form/src/Form/Handler.php
@@ -107,6 +107,17 @@ class Handler {
 			);
 		}
 
+		// Per-IP rate limit: a volume cap on top of the honeypot + time-trap, so
+		// a bot that clears those gates still can't flood the store and inbox.
+		// Only counts submissions that reach here; returns a retryable error past
+		// the threshold. Disable by filtering the limit to 0.
+		if ( $this->is_rate_limited() ) {
+			return $this->error(
+				'rate_limited',
+				__( 'You have sent several messages recently. Please wait a few minutes before sending another.', 'fivetwofive-contact-form' )
+			);
+		}
+
 		// 3. Sanitize + validate the real fields.
 		$name    = sanitize_text_field( (string) ( $input[ Form::FIELD_NAME ] ?? '' ) );
 		$email   = sanitize_email( (string) ( $input[ Form::FIELD_EMAIL ] ?? '' ) );
@@ -192,6 +203,87 @@ class Handler {
 		 * @param bool $enabled Whether the auto-reply will be sent.
 		 */
 		return (bool) apply_filters( 'fivetwofive_contact_form_send_autoreply', $enabled );
+	}
+
+	/**
+	 * Per-IP submission rate limit, backed by a short-lived transient counter.
+	 *
+	 * Counts submissions that reach this gate (i.e. that already cleared the
+	 * honeypot + time-trap) and blocks once an IP exceeds the limit within the
+	 * window. Only a salted hash of the IP is stored (the transient key), never
+	 * the raw address, and it auto-expires — so this adds no lasting PII.
+	 *
+	 * Fails open: when the client IP can't be determined, it never blocks.
+	 *
+	 * @since  1.4.0
+	 * @return bool True when the current IP is over its limit.
+	 */
+	private function is_rate_limited(): bool {
+		/**
+		 * Filter the maximum submissions allowed per IP per window. Return 0 (or
+		 * less) to disable the rate limit entirely.
+		 *
+		 * @since 1.4.0
+		 * @param int $limit Max submissions per window.
+		 */
+		$limit = (int) apply_filters( 'fivetwofive_contact_form_rate_limit', 5 );
+
+		if ( $limit <= 0 ) {
+			return false;
+		}
+
+		$ip = $this->client_ip();
+
+		if ( '' === $ip ) {
+			return false;
+		}
+
+		/**
+		 * Filter the rate-limit window, in seconds.
+		 *
+		 * @since 1.4.0
+		 * @param int $window Window length in seconds.
+		 */
+		$window = (int) apply_filters( 'fivetwofive_contact_form_rate_window', 10 * MINUTE_IN_SECONDS );
+
+		$key   = 'ftf_cf_rl_' . wp_hash( $ip );
+		$count = (int) get_transient( $key );
+
+		if ( $count >= $limit ) {
+			return true;
+		}
+
+		set_transient( $key, $count + 1, max( 1, $window ) );
+
+		return false;
+	}
+
+	/**
+	 * The client IP used for rate limiting.
+	 *
+	 * Defaults to REMOTE_ADDR (the peer address, not spoofable at the app
+	 * layer). A site behind a reverse proxy / CDN (e.g. Cloudflare) can filter
+	 * in the real client IP from a trusted header — never trust `X-Forwarded-*`
+	 * blindly, as it is caller-supplied.
+	 *
+	 * @since  1.4.0
+	 * @return string A validated IP address, or '' when none is available.
+	 */
+	private function client_ip(): string {
+		$raw = isset( $_SERVER['REMOTE_ADDR'] )
+			? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) )
+			: '';
+
+		/**
+		 * Filter the client IP used for rate limiting. Return a real client IP
+		 * from a trusted proxy header here when the site sits behind a CDN.
+		 *
+		 * @since 1.4.0
+		 * @param string $raw The peer IP from REMOTE_ADDR (may be empty).
+		 */
+		$ip = (string) apply_filters( 'fivetwofive_contact_form_client_ip', $raw );
+
+		return filter_var( $ip, FILTER_VALIDATE_IP ) ? $ip : '';
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Adds an **optional per-IP rate limit** as a third spam/abuse gate: a bot that clears the honeypot + time-trap still can't flood the `ftf_submission` store and the notification inbox.
- A short-lived **transient counter** blocks an IP past **N submissions per window** (default **5 / 10 min**), returning a retryable error — **HTTP 429** on the REST path.
- **Configurable from the settings page** — a new *Spam protection* section with an on/off toggle and a *max submissions per 10 minutes* field, plus the CDN caveat as inline help.
- Fully **filterable** and **privacy-conscious** (no raw IP stored). Bumps the plugin to **1.4.0**.

## Decisions baked in

- **Placed after the honeypot + time-trap, before storage.** Honeypot-caught bots already get a silent fake-success and never touch the store/inbox, so they don't consume the counter — the limit targets exactly the "clears those gates and floods" threat the issue describes. Counts every submission that reaches the gate (incl. ones that later fail validation), since the point is a volume cap.
- **No raw IP persisted (GDPR).** The transient key is `ftf_cf_rl_<wp_hash(ip)>` — a *salted* hash (not brute-forceable like plain md5), and the value is just a count. Auto-expires with the window, so there's no lasting PII and nothing to clean up on uninstall.
- **`REMOTE_ADDR` by default, filter for CDN setups.** Uses the peer address (not spoofable at the app layer). A Cloudflare/proxy-fronted site can supply the real client IP via `fivetwofive_contact_form_client_ip` — deliberately *not* trusting `X-Forwarded-*` automatically. **Note:** if the site is ever put behind a CDN without setting that filter, all visitors would share the CDN's IPs and could rate-limit each other — call it out at deploy time.
- **Fails open + disable-able.** No resolvable IP → never blocks. `fivetwofive_contact_form_rate_limit` returning `0` disables the gate entirely. Window tunable via `fivetwofive_contact_form_rate_window`.
- **429 status added** for the new `rate_limited` code in the REST status map (was falling to the generic 400).
- **Settings-page controls, with filters as overrides.** A *Spam protection* section adds an enable toggle and a *max submissions per 10 minutes* field, so an admin can tune or disable the limit without code. The settings act as defaults; `fivetwofive_contact_form_rate_limit` and `fivetwofive_contact_form_rate_limit_enabled` still override them (CDN / programmatic control). *(Added after review discussion — the section also homes the CDN caveat as help text.)*

## Test plan

- [x] `php -l` clean; `phpcbf` found nothing; `phpcs --standard=phpcs.xml.dist` — 0 violations (incl. the sanitized `$_SERVER['REMOTE_ADDR']` read)
- [x] Runtime on LocalWP via reflection on `is_rate_limited()` (no DB writes, no email — IP injected through the filter, only transients touched + cleaned up):
  - default limit 5 → `allow,allow,allow,allow,allow,BLOCK,BLOCK`; stored count caps at 5
  - transient key contains **no raw IP** (salted hash)
  - a **different IP** has its own counter (not blocked by the first IP's usage)
  - `rate_limit` filter = `0` → disabled even for a maxed IP
  - invalid/absent IP → **fails open** (allow)
- [x] `.pot` regenerated (new `rate_limited` string, Project-Id-Version 1.4.0)
- [x] Both entry points handle the new code: REST → 429; no-JS → generic `?ftf_contact=error` redirect (same path as `too_fast`/`invalid`)
- [x] No SCSS/JS — no rebuild

## Follow-ups

- Closes #100. Part of epic #102.
- The rate limit is now tunable from the settings page (toggle + threshold); the filters remain for CDN / programmatic overrides.
