### PR TITLE
fix(child-theme): correct style enqueue deps + harden functions.php (#164)

### DIFF
--- a/wp-content/themes/fivetwofive-theme-child/CHANGELOG.md
+++ b/wp-content/themes/fivetwofive-theme-child/CHANGELOG.md
@@ -6,8 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Direct-access guard (`ABSPATH` check) at the top of `functions.php`.
+- Text-domain loading via `load_child_theme_textdomain()` on `after_setup_theme`, making the child's UI strings translatable.
+
 ### Changed
 - Replaced jQuery Fancybox with GLightbox in the `module-content-and-media` override, matching the parent theme's Phase 3 library modernization. Removes this module's jQuery dependency for the image/video lightbox.
+
+### Fixed
+- Corrected the child stylesheet dependency chain in `functions.php` (#164). The child re-enqueued the parent-owned `fivetwofive-theme-style` handle with a dependency array that WordPress silently discarded (the handle is already registered by the parent at priority 5), and that array named `fivetwofive-theme-template-module` — a handle the parent only registers on the module-template / `ftf_event` routes. The compiled SASS bundle now depends directly on the always-registered `fivetwofive-theme-main` (plus `fivetwofive-theme-style`), so its cascade after the parent framework is guaranteed by contract rather than by enqueue order. No visual change; removes latent dead/misleading code.
 
 ## [1.1.3] - 2025-05-08
 

--- a/wp-content/themes/fivetwofive-theme-child/functions.php
+++ b/wp-content/themes/fivetwofive-theme-child/functions.php
@@ -7,6 +7,18 @@
  * @since 1.1.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // No direct access.
+}
+
+/**
+ * Load the child theme's text domain so its UI strings are translatable.
+ */
+add_action( 'after_setup_theme', 'fivetwofive_child_setup' );
+function fivetwofive_child_setup() {
+    load_child_theme_textdomain( 'fivetwofive-theme-child', get_stylesheet_directory() . '/languages' );
+}
+
 /**
  * Enqueue child theme styles and GSAP scripts
  *
@@ -19,19 +31,25 @@ add_action( 'wp_enqueue_scripts', 'fivetwofive_child_enqueue_assets' );
 function fivetwofive_child_enqueue_assets() {
     $theme = wp_get_theme();
 
-    // Enqueue child theme style.css (for metadata and light overrides)
-    wp_enqueue_style(
-        'fivetwofive-theme-style',
-        get_stylesheet_uri(),
-        array( 'fivetwofive-theme-main', 'fivetwofive-theme-template-module' ),
-        $theme->get( 'Version' )
-    );
-
-    // Enqueue compiled SASS stylesheet, dependent on child theme style.css
+    // Compiled SASS bundle — the child's main stylesheet.
+    //
+    // The parent already enqueues this child's style.css (handle
+    // 'fivetwofive-theme-style', via get_stylesheet_uri()) and the framework CSS
+    // ('fivetwofive-theme-main') on every route at priority 5, so this only layers
+    // the bundle on top — no need to re-enqueue style.css here. Re-registering an
+    // already-registered handle is a no-op in WP_Dependencies, so a dependency array
+    // on that handle would be silently dropped anyway.
+    //
+    // Depend on 'fivetwofive-theme-main' (always registered) so the bundle reliably
+    // cascades after the parent framework, and on 'fivetwofive-theme-style' so it also
+    // follows the child's light style.css overrides. We deliberately do NOT depend on
+    // 'fivetwofive-theme-template-module': the parent registers that only on the
+    // module-template / ftf_event routes, so depending on it would drop this bundle on
+    // home, archives, posts, and regular pages.
     wp_enqueue_style(
         'fivetwofive-theme-child-sass',
         get_stylesheet_directory_uri() . '/assets/dist/css/style.css',
-        array( 'fivetwofive-theme-style' ),
+        array( 'fivetwofive-theme-main', 'fivetwofive-theme-style' ),
         $theme->get( 'Version' )
     );
 


### PR DESCRIPTION
## Summary

- Corrects `fivetwofive-theme-child/functions.php`'s style enqueue: drops a redundant re-enqueue of the parent-owned `fivetwofive-theme-style` handle, and points the compiled SASS bundle's dependency directly at the always-registered `fivetwofive-theme-main` instead of a dead/fragile dependency array.
- Adds the `ABSPATH` direct-access guard and `load_child_theme_textdomain()` — both already present in the sibling `fivetwofive-theme-child-editorial` theme, now brought to parity here.
- No visual or behavioral change. This is the first of four sub-issues under epic #163 (porting editorial-child practices back to the portfolio child).

## Decisions baked in

- **Removed the `fivetwofive-theme-style` re-enqueue entirely, rather than fixing its dependency array in place** — the parent (`fivetwofive-theme/inc/public/assets.php:130`) already enqueues that exact handle globally at priority 5 with empty deps. `WP_Dependencies::add()` returns `false` for an already-registered handle, so the child's declared `array( 'fivetwofive-theme-main', 'fivetwofive-theme-template-module' )` was silently discarded — dead code, not a live bug. Re-enqueuing it added nothing; removing it is more honest than "fixing" deps that were never applied.
- **Depend the compiled bundle on `fivetwofive-theme-main`, not `fivetwofive-theme-template-module`** — the parent only registers `-template-module` conditionally, on `template-module.php` / `ftf_event` routes (`assets.php:165`). The old dead array named it anyway; had it ever become live (e.g. someone "cleans up" the redundant re-enqueue without checking), it would have dropped the child's compiled stylesheet on every normal route. Verified this failure mode directly — see test plan.
- **No CHANGELOG version bump** — this repo's child-theme CHANGELOG accumulates entries under `[Unreleased]` between releases (see the existing Fancybox→GLightbox entry already sitting there); versioning happens separately per the metadata-hygiene follow-up (#165).

## Test plan

- No SCSS/JS source changed, so no asset rebuild was needed (confirmed via `git diff HEAD --name-only`: only `functions.php` and `CHANGELOG.md`).
- `php -l functions.php` — no syntax errors.
- Replayed the parent-then-child enqueue sequence through the **actual installed WordPress 7.0.1 `WP_Dependencies` class** (loaded standalone, outside a full bootstrap) to compare old vs. new code on both a normal route and a `template-module.php` route:
  - [x] Old code vs. new code: **identical resolved print order** on both routes (`style → main → child-sass`, and `style → main → template-module → child-sass` on the module route) — confirms the fix is a no-op for real page output.
  - [x] Confirmed the old dependency array was genuinely inert: the child's re-`add()` of `fivetwofive-theme-style` returned `false`, with the handle's stored deps remaining `[]`.
  - [x] Confirmed the risk the new code removes: replaying the old array as if it were live (i.e. if `fivetwofive-theme-style` were ever *not* pre-registered by the parent) causes WP to **drop the child bundle entirely** on a normal route and log `_doing_it_wrong(): dependencies that are not registered: fivetwofive-theme-template-module`.
- Visual verification on the live/deployed theme (view-source across home, a single post, an archive, and a `template-module.php` page) is still pending — noted as the acceptance step on #164, best run once this merges since the active site serves the deployed checkout, not this branch's worktree.

## Follow-ups

- [#165](https://github.com/jaballer/fivetwofive-cw/issues/165) — metadata + build hygiene (`Requires PHP`, version drift, `browserslist`)
- [#166](https://github.com/jaballer/fivetwofive-cw/issues/166) — migrate SCSS `@import` → `@use`
- [#167](https://github.com/jaballer/fivetwofive-cw/issues/167) — ITCSS structure + design-token layer (needs visual QA)
- Part of epic [#163](https://github.com/jaballer/fivetwofive-cw/issues/163)

Closes #164