### PR TITLE
chore(child-theme): metadata + build hygiene pass (#165)

### DIFF
--- a/wp-content/themes/fivetwofive-theme-child/.gitignore
+++ b/wp-content/themes/fivetwofive-theme-child/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .DS_Store
-*.map 
+*.map
+.env

--- a/wp-content/themes/fivetwofive-theme-child/CHANGELOG.md
+++ b/wp-content/themes/fivetwofive-theme-child/CHANGELOG.md
@@ -9,9 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Direct-access guard (`ABSPATH` check) at the top of `functions.php`.
 - Text-domain loading via `load_child_theme_textdomain()` on `after_setup_theme`, making the child's UI strings translatable.
+- `Requires PHP: 8.0` to the `style.css` header, documenting the floor the parent theme already requires (#165).
+- `browserslist` config (`["defaults"]`) to `package.json`, making autoprefixer's build target explicit instead of implicit (#165).
+- `.env` to `.gitignore` for parity with the editorial child theme; cosmetic only — the repo-root `.gitignore` already ignores `.env` globally (#165).
 
 ### Changed
 - Replaced jQuery Fancybox with GLightbox in the `module-content-and-media` override, matching the parent theme's Phase 3 library modernization. Removes this module's jQuery dependency for the image/video lightbox.
+- Bumped `package.json` version from `1.0.0` to `1.0.1` to match `style.css`, which `functions.php` reads for cache-busting via `$theme->get( 'Version' )` (#165).
 
 ### Fixed
 - Corrected the child stylesheet dependency chain in `functions.php` (#164). The child re-enqueued the parent-owned `fivetwofive-theme-style` handle with a dependency array that WordPress silently discarded (the handle is already registered by the parent at priority 5), and that array named `fivetwofive-theme-template-module` — a handle the parent only registers on the module-template / `ftf_event` routes. The compiled SASS bundle now depends directly on the always-registered `fivetwofive-theme-main` (plus `fivetwofive-theme-style`), so its cascade after the parent framework is guaranteed by contract rather than by enqueue order. No visual change; removes latent dead/misleading code.

--- a/wp-content/themes/fivetwofive-theme-child/package.json
+++ b/wp-content/themes/fivetwofive-theme-child/package.json
@@ -1,12 +1,15 @@
 {
   "name": "fivetwofive-theme-child",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Child theme for FiveTwoFive",
   "scripts": {
     "start": "gulp",
     "build": "gulp build",
     "watch": "gulp watch"
   },
+  "browserslist": [
+    "defaults"
+  ],
   "devDependencies": {
     "browser-sync": "^2.29.3",
     "dotenv": "^16.3.1",

--- a/wp-content/themes/fivetwofive-theme-child/style.css
+++ b/wp-content/themes/fivetwofive-theme-child/style.css
@@ -4,6 +4,7 @@
  Author:       FiveTwoFive Creative.
  Template:     fivetwofive-theme
  Version:      1.0.1
+ Requires PHP: 8.0
  License:      GNU General Public License v2 or later
  License URI:  http://www.gnu.org/licenses/gpl-2.0.html
  Tags:         light, dark, two-columns, right-sidebar, responsive-layout, accessibility-ready


### PR DESCRIPTION
## Summary

- Declares `Requires PHP: 8.0` in `style.css` — the parent theme already requires it; the child was silent.
- Bumps `package.json` from `1.0.0` to `1.0.1` to match `style.css`.
- Adds an explicit `browserslist` config (`["defaults"]`) so autoprefixer's build target is documented rather than implicit.
- Adds `.env` to `.gitignore` for parity with the sibling editorial child theme.
- Second of four sub-issues under epic #163 (porting `fivetwofive-theme-child-editorial` practices back to the portfolio child). No functional or visual change.

## Decisions baked in

- **`Requires PHP: 8.0`, not a lower/newer floor** — verified the parent theme (`fivetwofive-theme/style.css`) already declares this exact requirement, and confirmed locally that neither theme uses any PHP 8-only syntax that would need a *higher* floor. This documents an existing constraint rather than inventing one.
- **`.env` in `.gitignore` is cosmetic, not a leak fix** — the repo-root `.gitignore` is deny-all-then-whitelist and already ignores `.env` globally; confirmed via `git ls-files` that no `.env` was ever tracked here. Added purely for self-documentation/parity with the editorial child.
- **No dependency version bumps** — `browserslist` is new config, not a new dependency; `devDependencies`/`dependencies` are untouched. Ran `npm ls bootstrap` as a sanity check (per a past incident where a blanket update silently bumped prod deps) — this theme doesn't even depend on bootstrap, so no risk here.

## Test plan

- [x] `npm ci` (not `npm install`) before building, to rule out stale-`node_modules` phantom diffs.
- [x] `npm run build` — completed with **no browserslist warning**.
- [x] `git diff -- assets/dist/` after the build — **empty**; compiled CSS/JS output is byte-identical to before, confirming autoprefixer's implicit target already matched `["defaults"]`.
- [x] `python3 -c "import json; json.load(open('package.json'))"` — valid JSON.
- [x] Grepped this theme's `CLAUDE.md`/`README.md` for stale version references — none found.

## Follow-ups

- [#166](https://github.com/jaballer/fivetwofive-cw/issues/166) — migrate SCSS `@import` → `@use` (the build already emits Dart Sass deprecation warnings for this, unrelated to browserslist)
- [#167](https://github.com/jaballer/fivetwofive-cw/issues/167) — ITCSS structure + design-token layer (needs visual QA)
- Part of epic [#163](https://github.com/jaballer/fivetwofive-cw/issues/163)

Closes #165